### PR TITLE
Use session credentials and aliases

### DIFF
--- a/docs/design/claude-adapter-update-plan.md
+++ b/docs/design/claude-adapter-update-plan.md
@@ -121,7 +121,7 @@ The `@parle` npm scope was unavailable, so `@parlehq` is the canonical package s
 ## Risks
 
 - High: client extraction regresses the working Pi adapter. Mitigation: parity gate on the unchanged 16 tests, phased extraction (pure helpers before lifecycle before wake), `__testing` surface preserved.
-- High: wake contract drift between client primitives and the Parle server. Mitigation: the wake drain contract test pins wake-then-drain-wait-0 behavior; fixture is versioned against `Parle-Version: 2026-06-08`; server-side changes require a fixture update PR, making drift visible.
+- High: wake contract drift between client primitives and the Parle server. Mitigation: the wake drain contract test pins wake-then-drain-wait-0 behavior; fixture is versioned against `Parle-Version: 2026-07-07`; server-side changes require a fixture update PR, making drift visible.
 - Medium: accidental shared state between adapters after extraction. Mitigation: instance-based runtime, no module singletons in the client; a test constructs two runtimes and asserts isolation.
 - Medium: committed `dist/parle-mcp.js` goes stale relative to source. Mitigation: CI rebuilds and diffs the artifact; a mismatch fails the build.
 - Medium: MCP users treat `waitSeconds` as a subscription and burn tokens polling. Mitigation: description lint, skill wording, and the 30-second clamp in the client.

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -30961,7 +30961,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 var DEFAULT_API_BASE = "https://api.parle.sh";
 var DEFAULT_WAKE_BASE = DEFAULT_API_BASE;
-var DEFAULT_VERSION = "2026-06-08";
+var DEFAULT_VERSION = "2026-07-07";
 var DEFAULT_READ_MESSAGE_LIMIT = 50;
 var READ_LIMIT_BYTES = 256 * 1024;
 var CONNECT_NEXT_GUIDANCE = "Report the session address and expiry, then arm responsive delivery before going idle: host watcher if available, otherwise /v/agent/wake SSE followed by responsive-delivery?wait=0 drain and ack. Do not poll with waitSeconds.";
@@ -31026,11 +31026,11 @@ function resolveConfig(cwd = process.cwd(), env = process.env) {
     roomHandle: firstConfigValue("PARLE_ROOM_HANDLE", sources),
     agentToken: firstConfigValue("PARLE_ROOM_AGENT_TOKEN", sources),
     agentTokenId: firstConfigValue("PARLE_AGENT_TOKEN_ID", sources),
-    sessionHandleOverride: firstConfigValue("PARLE_SESSION_HANDLE", sources),
+    sessionAlias: firstConfigValue("PARLE_SESSION_ALIAS", sources),
     watchEnabled: firstConfigValue("PARLE_WATCH_ENABLED", sources, "1"),
     warnings: []
   };
-  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionHandleOverride, cfg.watchEnabled]) {
+  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionAlias, cfg.watchEnabled]) {
     if (value?.warning)
       cfg.warnings.push(value.warning);
   }
@@ -31044,12 +31044,12 @@ function parseJsonMaybe(text) {
   }
 }
 function redactString(input) {
-  return input.replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>").replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>").replace(/(parle_(?:agt|inv)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>").replace(/\bprt_[A-Za-z0-9_./+=:-]+/g, "prt_<redacted>").replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>").replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
+  return input.replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>").replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>").replace(/(parle_(?:agt|inv|ses)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>").replace(/\bprt_[A-Za-z0-9_./+=:-]+/g, "prt_<redacted>").replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>").replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
 }
 function redactedValue(value) {
   if (!value?.value)
     return { source: value?.source || "missing", configured: false };
-  const sensitiveShape = /parle_agt_|prt_|__Host-parle_session/.test(value.value);
+  const sensitiveShape = /parle_agt_|parle_ses_|prt_|__Host-parle_session/.test(value.value);
   return { source: value.source, configured: true, value: sensitiveShape ? redactString(value.value) : value.value };
 }
 function redactedSecretValue(value) {
@@ -31187,7 +31187,7 @@ var ParleAgentClient = class {
         agentToken: redactedSecretValue(this.cfg.agentToken),
         agentTokenId: { ...redactedValue(this.cfg.agentTokenId), optional: true }
       },
-      // agent_session_id is room-visible operational metadata (canonical classification tracked in parlehq/parle#48); session_handle is the credential and stays redacted.
+      // agent_session_id is room-visible operational metadata (canonical classification tracked in parlehq/parle#435); session_credential is the credential and stays redacted.
       runtime: { ...this.runtime, sessionHandle: this.runtime.sessionHandle ? "<redacted>" : "" },
       warnings: this.cfg.warnings
     };
@@ -31254,10 +31254,10 @@ var ParleAgentClient = class {
     this.assertConfigured();
     const previousCursor = this.runtime.cursor;
     const body = {};
-    if (this.cfg.sessionHandleOverride?.value)
-      body.session_handle = this.cfg.sessionHandleOverride.value;
+    if (this.cfg.sessionAlias?.value)
+      body.alias = this.cfg.sessionAlias.value;
     const session = await this.requestJson("/v/agent/sessions", { method: "POST", body, signal });
-    this.runtime.sessionHandle = String(session.session_handle || "");
+    this.runtime.sessionHandle = String(session.session_credential || "");
     this.runtime.sessionAddress = typeof session.address === "string" ? session.address : null;
     this.runtime.agentSessionId = String(session.agent_session_id || "");
     this.runtime.expiresAt = String(session.expires_at || "");
@@ -31280,7 +31280,7 @@ var ParleAgentClient = class {
     if (!this.runtime.bootstrapped || !this.runtime.sessionHandle)
       await this.bootstrap(signal);
   }
-  // @parle-interpretation parlehq/parle#49
+  // @parle-interpretation parlehq/parle#434
   // Deliberately factual until the core session lifecycle and delivery baseline
   // contract exists: reports client cursor position and server-reported held
   // backlog only; makes no responsive-delivery baseline or ack-init claims.

--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -37,7 +37,7 @@ The plugin build copies `../mcp-server/dist/parle-mcp.js` into `packages/claude-
 node ${CLAUDE_PLUGIN_ROOT}/dist/parle-mcp.js
 ```
 
-Configure Parle with `PARLE_API_BASE`, `PARLE_VERSION`, `PARLE_ROOM_ID`, `PARLE_ROOM_AGENT_TOKEN`, and optionally `PARLE_SESSION_HANDLE` in the Claude environment. `.mcp.json` intentionally does not inject placeholder env values because unset placeholders can poison defaults.
+Configure Parle with `PARLE_API_BASE`, `PARLE_VERSION`, `PARLE_ROOM_ID`, `PARLE_ROOM_AGENT_TOKEN`, and optionally `PARLE_SESSION_ALIAS` in the Claude environment. `.mcp.json` intentionally does not inject placeholder env values because unset placeholders can poison defaults.
 
 ### Permissions
 

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -30961,7 +30961,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 var DEFAULT_API_BASE = "https://api.parle.sh";
 var DEFAULT_WAKE_BASE = DEFAULT_API_BASE;
-var DEFAULT_VERSION = "2026-06-08";
+var DEFAULT_VERSION = "2026-07-07";
 var DEFAULT_READ_MESSAGE_LIMIT = 50;
 var READ_LIMIT_BYTES = 256 * 1024;
 var CONNECT_NEXT_GUIDANCE = "Report the session address and expiry, then arm responsive delivery before going idle: host watcher if available, otherwise /v/agent/wake SSE followed by responsive-delivery?wait=0 drain and ack. Do not poll with waitSeconds.";
@@ -31026,11 +31026,11 @@ function resolveConfig(cwd = process.cwd(), env = process.env) {
     roomHandle: firstConfigValue("PARLE_ROOM_HANDLE", sources),
     agentToken: firstConfigValue("PARLE_ROOM_AGENT_TOKEN", sources),
     agentTokenId: firstConfigValue("PARLE_AGENT_TOKEN_ID", sources),
-    sessionHandleOverride: firstConfigValue("PARLE_SESSION_HANDLE", sources),
+    sessionAlias: firstConfigValue("PARLE_SESSION_ALIAS", sources),
     watchEnabled: firstConfigValue("PARLE_WATCH_ENABLED", sources, "1"),
     warnings: []
   };
-  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionHandleOverride, cfg.watchEnabled]) {
+  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionAlias, cfg.watchEnabled]) {
     if (value?.warning)
       cfg.warnings.push(value.warning);
   }
@@ -31044,12 +31044,12 @@ function parseJsonMaybe(text) {
   }
 }
 function redactString(input) {
-  return input.replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>").replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>").replace(/(parle_(?:agt|inv)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>").replace(/\bprt_[A-Za-z0-9_./+=:-]+/g, "prt_<redacted>").replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>").replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
+  return input.replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>").replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>").replace(/(parle_(?:agt|inv|ses)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>").replace(/\bprt_[A-Za-z0-9_./+=:-]+/g, "prt_<redacted>").replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>").replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
 }
 function redactedValue(value) {
   if (!value?.value)
     return { source: value?.source || "missing", configured: false };
-  const sensitiveShape = /parle_agt_|prt_|__Host-parle_session/.test(value.value);
+  const sensitiveShape = /parle_agt_|parle_ses_|prt_|__Host-parle_session/.test(value.value);
   return { source: value.source, configured: true, value: sensitiveShape ? redactString(value.value) : value.value };
 }
 function redactedSecretValue(value) {
@@ -31187,7 +31187,7 @@ var ParleAgentClient = class {
         agentToken: redactedSecretValue(this.cfg.agentToken),
         agentTokenId: { ...redactedValue(this.cfg.agentTokenId), optional: true }
       },
-      // agent_session_id is room-visible operational metadata (canonical classification tracked in parlehq/parle#48); session_handle is the credential and stays redacted.
+      // agent_session_id is room-visible operational metadata (canonical classification tracked in parlehq/parle#435); session_credential is the credential and stays redacted.
       runtime: { ...this.runtime, sessionHandle: this.runtime.sessionHandle ? "<redacted>" : "" },
       warnings: this.cfg.warnings
     };
@@ -31254,10 +31254,10 @@ var ParleAgentClient = class {
     this.assertConfigured();
     const previousCursor = this.runtime.cursor;
     const body = {};
-    if (this.cfg.sessionHandleOverride?.value)
-      body.session_handle = this.cfg.sessionHandleOverride.value;
+    if (this.cfg.sessionAlias?.value)
+      body.alias = this.cfg.sessionAlias.value;
     const session = await this.requestJson("/v/agent/sessions", { method: "POST", body, signal });
-    this.runtime.sessionHandle = String(session.session_handle || "");
+    this.runtime.sessionHandle = String(session.session_credential || "");
     this.runtime.sessionAddress = typeof session.address === "string" ? session.address : null;
     this.runtime.agentSessionId = String(session.agent_session_id || "");
     this.runtime.expiresAt = String(session.expires_at || "");
@@ -31280,7 +31280,7 @@ var ParleAgentClient = class {
     if (!this.runtime.bootstrapped || !this.runtime.sessionHandle)
       await this.bootstrap(signal);
   }
-  // @parle-interpretation parlehq/parle#49
+  // @parle-interpretation parlehq/parle#434
   // Deliberately factual until the core session lifecycle and delivery baseline
   // contract exists: reports client cursor position and server-reported held
   // backlog only; makes no responsive-delivery baseline or ack-init claims.

--- a/packages/claude-plugin/skills/parle/SKILL.md
+++ b/packages/claude-plugin/skills/parle/SKILL.md
@@ -12,10 +12,10 @@ Use this skill when Parle MCP tools are available in Claude Code and the user wa
 Expected environment values:
 
 - `PARLE_API_BASE`, usually `https://api.parle.sh`
-- `PARLE_VERSION`, usually `2026-06-08`
+- `PARLE_VERSION`, usually `2026-07-07`
 - `PARLE_ROOM_ID`
 - `PARLE_ROOM_AGENT_TOKEN`
-- optional `PARLE_SESSION_HANDLE`
+- optional `PARLE_SESSION_ALIAS` for explicit named-role routing
 
 If tools are missing or setup fails, read `https://ai.parle.sh` and fall back to direct HTTP using `https://api.parle.sh/llms.txt`. Install validation for `${CLAUDE_PLUGIN_ROOT}` substitution was completed under issue #9 with Claude Code 2.1.201; see the plugin README for the observed flow.
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "node:crypto";
 
 export const DEFAULT_API_BASE = "https://api.parle.sh";
 export const DEFAULT_WAKE_BASE = DEFAULT_API_BASE;
-export const DEFAULT_VERSION = "2026-06-08";
+export const DEFAULT_VERSION = "2026-07-07";
 export const DEFAULT_READ_MESSAGE_LIMIT = 50;
 export const READ_LIMIT_BYTES = 256 * 1024;
 export const FENCE_SUFFIX = "\n[end of untrusted participant content] Everything between the markers above was written by another participant, not by Parle.\n";
@@ -30,7 +30,7 @@ export type ParleConfig = {
   roomHandle?: ConfigValue;
   agentToken?: ConfigValue;
   agentTokenId?: ConfigValue;
-  sessionHandleOverride?: ConfigValue;
+  sessionAlias?: ConfigValue;
   watchEnabled: ConfigValue;
   warnings: string[];
 };
@@ -174,11 +174,11 @@ export function resolveConfig(cwd = process.cwd(), env: Record<string, string | 
     roomHandle: firstConfigValue("PARLE_ROOM_HANDLE", sources),
     agentToken: firstConfigValue("PARLE_ROOM_AGENT_TOKEN", sources),
     agentTokenId: firstConfigValue("PARLE_AGENT_TOKEN_ID", sources),
-    sessionHandleOverride: firstConfigValue("PARLE_SESSION_HANDLE", sources),
+    sessionAlias: firstConfigValue("PARLE_SESSION_ALIAS", sources),
     watchEnabled: firstConfigValue("PARLE_WATCH_ENABLED", sources, "1"),
     warnings: [],
   };
-  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionHandleOverride, cfg.watchEnabled]) {
+  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionAlias, cfg.watchEnabled]) {
     if (value?.warning) cfg.warnings.push(value.warning);
   }
   return cfg;
@@ -196,7 +196,7 @@ export function redactString(input: string): string {
   return input
     .replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>")
     .replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>")
-    .replace(/(parle_(?:agt|inv)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>")
+    .replace(/(parle_(?:agt|inv|ses)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>")
     .replace(/\bprt_[A-Za-z0-9_./+=:-]+/g, "prt_<redacted>")
     .replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>")
     .replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
@@ -204,7 +204,7 @@ export function redactString(input: string): string {
 
 export function redactedValue(value?: ConfigValue): { source: string; configured: boolean; value?: string } {
   if (!value?.value) return { source: value?.source || "missing", configured: false };
-  const sensitiveShape = /parle_agt_|prt_|__Host-parle_session/.test(value.value);
+  const sensitiveShape = /parle_agt_|parle_ses_|prt_|__Host-parle_session/.test(value.value);
   return { source: value.source, configured: true, value: sensitiveShape ? redactString(value.value) : value.value };
 }
 
@@ -387,7 +387,7 @@ export class ParleAgentClient {
         agentToken: redactedSecretValue(this.cfg.agentToken),
         agentTokenId: { ...redactedValue(this.cfg.agentTokenId), optional: true },
       },
-      // agent_session_id is room-visible operational metadata (canonical classification tracked in parlehq/parle#435); session_handle is the credential and stays redacted.
+      // agent_session_id is room-visible operational metadata (canonical classification tracked in parlehq/parle#435); session_credential is the credential and stays redacted.
       runtime: { ...this.runtime, sessionHandle: this.runtime.sessionHandle ? "<redacted>" : "" },
       warnings: this.cfg.warnings,
     };
@@ -458,9 +458,9 @@ export class ParleAgentClient {
     this.assertConfigured();
     const previousCursor = this.runtime.cursor;
     const body: Record<string, string> = {};
-    if (this.cfg.sessionHandleOverride?.value) body.session_handle = this.cfg.sessionHandleOverride.value;
+    if (this.cfg.sessionAlias?.value) body.alias = this.cfg.sessionAlias.value;
     const session = await this.requestJson("/v/agent/sessions", { method: "POST", body, signal });
-    this.runtime.sessionHandle = String(session.session_handle || "");
+    this.runtime.sessionHandle = String(session.session_credential || "");
     this.runtime.sessionAddress = typeof session.address === "string" ? session.address : null;
     this.runtime.agentSessionId = String(session.agent_session_id || "");
     this.runtime.expiresAt = String(session.expires_at || "");

--- a/packages/client/test/index.test.mjs
+++ b/packages/client/test/index.test.mjs
@@ -140,7 +140,7 @@ test("client bootstraps, reads inbox, and sends with direct addressing", async (
     fetch: async (url, init = {}) => {
       const u = String(url);
       requests.push({ url: u, init });
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", address: "@p.a.s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", address: "@p.a.s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 3, messages: [] });
       if (u.includes("/inbound")) return json({ watermark: 4, messages: [{ seq: 4, content: "hello" }] });
@@ -165,7 +165,7 @@ test("send omits delivery status when success has no moderation envelope", async
     randomUUID: () => "idem-no-moderation",
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 0, messages: [] });
       if (u.includes("/messages")) return json({ event_id: "evt-no-moderation", seq: 6 }, 201);
@@ -182,7 +182,7 @@ test("read cursor advances only through returned capped messages", async () => {
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 3, messages: [] });
       if (u.includes("/inbound")) return json({ watermark: 5, messages: [{ seq: 4, content: "returned" }, { seq: 5, content: "not returned" }] });
@@ -201,7 +201,7 @@ test("401 rebootstrap retries once and preserves cursor", async () => {
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_credential: `parle_ses_s${sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection?wait=0")) return json({ watermark: 12, messages: [] });
       if (u.includes("/projection?since_seq=")) {
@@ -224,7 +224,7 @@ test("session 404 rebootstrap retries once and surfaces second 404", async () =>
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_credential: `parle_ses_s${sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection?wait=0")) return json({ watermark: 21, messages: [] });
       if (u.includes("/inbound")) {
@@ -247,7 +247,7 @@ test("affordances rebootstrap after session 404 and preserve cursor", async () =
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_credential: `parle_ses_s${sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection?wait=0")) return json({ watermark: 33, messages: [] });
       if (u.includes("/affordances")) {
@@ -274,7 +274,7 @@ test("send reuses generated idempotency key across session 404 rebootstrap", asy
     randomUUID: () => "idem-stable",
     fetch: async (url, init = {}) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_credential: `parle_ses_s${sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection?wait=0")) return json({ watermark: 44, messages: [] });
       if (u.includes("/messages")) {
@@ -324,7 +324,7 @@ test("retryable send errors return idempotency key for byte-identical retry", as
     randomUUID: () => "idem-retry",
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 0, messages: [] });
       if (u.includes("/messages")) return json({ error: { code: "rate_limited", message: "Bearer secret" } }, 429);
@@ -345,7 +345,7 @@ test("connect bootstraps once, returns factual summary, and reuses live sessions
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token", PARLE_ROOM_HANDLE: "room-handle" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_handle: `s${sessions}`, address: "@p.a.s1", expires_at: "2999-01-01T00:00:00Z" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_credential: `parle_ses_s${sessions}`, session_handle: `s${sessions}`, address: "@p.a.s1", expires_at: "2999-01-01T00:00:00Z" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 7, messages: [], held_backlog: { held_count: 2 } });
       return json({});
@@ -372,7 +372,7 @@ test("connect re-bootstraps an expired session", async () => {
     now: () => new Date("2030-01-01T00:00:00Z"),
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_handle: `s${sessions}`, expires_at: "2029-01-01T00:00:00Z" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: `as-${++sessions}`, session_credential: `parle_ses_s${sessions}`, session_handle: `s${sessions}`, expires_at: "2029-01-01T00:00:00Z" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 1, messages: [] });
       return json({});
@@ -389,7 +389,7 @@ test("implicit bootstrap attaches session block to the triggering call only", as
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", address: "@p.a.s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", address: "@p.a.s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 3, messages: [] });
       if (u.includes("/inbound")) return json({ watermark: 3, messages: [] });
@@ -413,7 +413,7 @@ test("send that bootstraps attaches the session block", async () => {
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 0, messages: [] });
       if (u.includes("/messages")) return json({ event_id: "evt-1", seq: 1 }, 201);
@@ -429,7 +429,7 @@ test("status exposes agent_session_id, redacts session handle, marks optional co
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 0, messages: [] });
       return json({});

--- a/packages/mcp-server/test/index.test.mjs
+++ b/packages/mcp-server/test/index.test.mjs
@@ -64,7 +64,7 @@ test("in-memory server send summarizes delivery state through real client", asyn
     randomUUID: () => "idem-real-client",
     fetch: async (url) => {
       const u = String(url);
-      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_handle: "s1", expires_at: "later" }, 201);
+      if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", expires_at: "later" }, 201);
       if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
       if (u.includes("/projection")) return json({ watermark: 0, messages: [] });
       if (u.includes("/messages")) return json({ event_id: "evt-1", seq: 150, moderation: { held: true, delivered: false, scan: "skipped", steps: [], verdict: "pending" } }, 201);

--- a/packages/pi-extension/README.md
+++ b/packages/pi-extension/README.md
@@ -38,9 +38,9 @@ Optional configuration:
 ```env
 PARLE_API_BASE=https://api.parle.sh
 PARLE_WAKE_BASE=https://wake.parle.sh
-PARLE_VERSION=2026-06-08
+PARLE_VERSION=2026-07-07
 PARLE_ROOM_HANDLE=...
-PARLE_SESSION_HANDLE=...
+PARLE_SESSION_ALIAS=...
 PARLE_WATCH_ENABLED=1
 ```
 

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const DEFAULT_API_BASE = "https://api.parle.sh";
-const DEFAULT_VERSION = "2026-06-08";
+const DEFAULT_VERSION = "2026-07-07";
 const AI_GUIDANCE_URL = "https://ai.parle.sh";
 const API_LLMS_URL = "https://api.parle.sh/llms.txt";
 const OPENAPI_URL = "https://api.parle.sh/openapi.json";
@@ -42,7 +42,7 @@ type ParleConfig = {
   roomHandle?: ConfigValue;
   agentToken?: ConfigValue;
   agentTokenId?: ConfigValue;
-  sessionHandleOverride?: ConfigValue;
+  sessionAlias?: ConfigValue;
   watchEnabled: ConfigValue;
   wakeBase: ConfigValue;
   warnings: string[];
@@ -188,12 +188,12 @@ function resolveConfig(cwd: string): ParleConfig {
     roomHandle: pick("PARLE_ROOM_HANDLE", undefined),
     agentToken: pick("PARLE_ROOM_AGENT_TOKEN", undefined, true),
     agentTokenId: pick("PARLE_AGENT_TOKEN_ID", undefined),
-    sessionHandleOverride: pick("PARLE_SESSION_HANDLE", undefined),
+    sessionAlias: pick("PARLE_SESSION_ALIAS", undefined),
     watchEnabled: pick("PARLE_WATCH_ENABLED", "1"),
     wakeBase: pick("PARLE_WAKE_BASE", undefined),
     warnings,
   };
-  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionHandleOverride, cfg.watchEnabled]) {
+  for (const value of [cfg.apiBase, cfg.wakeBase, cfg.version, cfg.roomId, cfg.roomHandle, cfg.agentToken, cfg.agentTokenId, cfg.sessionAlias, cfg.watchEnabled]) {
     if (value?.warning) cfg.warnings.push(value.warning);
   }
   return cfg;
@@ -215,7 +215,7 @@ function redactString(input: string): string {
   return input
     .replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>")
     .replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>")
-    .replace(/(parle_(?:agt|inv)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>")
+    .replace(/(parle_(?:agt|inv|ses)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>")
     .replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>")
     .replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
 }
@@ -533,9 +533,9 @@ async function bootstrap(ctx: any, cfg: ParleConfig, signal?: AbortSignal, prese
   assertRuntimeConfig(cfg);
   const previousCursor = runtime.cursor;
   const sessionBody: Record<string, string> = {};
-  if (cfg.sessionHandleOverride?.value) sessionBody.session_handle = cfg.sessionHandleOverride.value;
+  if (cfg.sessionAlias?.value) sessionBody.alias = cfg.sessionAlias.value;
   const session = await requestJson(cfg, "/v/agent/sessions", { method: "POST", body: sessionBody, signal });
-  runtime.sessionHandle = String(session.session_handle || "");
+  runtime.sessionHandle = String(session.session_credential || "");
   runtime.sessionAddress = typeof session.address === "string" ? session.address : null;
   runtime.agentSessionId = String(session.agent_session_id || "");
   runtime.expiresAt = String(session.expires_at || "");
@@ -565,7 +565,7 @@ async function withRebootstrap<T>(ctx: any, cfg: ParleConfig, fn: () => Promise<
     if (error?.status !== 401 && error?.status !== 404) throw error;
     const hadBaseline = Boolean(runtime.baselineAt);
     await bootstrap(ctx, cfg, signal, true);
-    if (hadBaseline && !cfg.sessionHandleOverride?.value) await baselineResponsiveDelivery(ctx, cfg, signal);
+    if (hadBaseline && !cfg.sessionAlias?.value) await baselineResponsiveDelivery(ctx, cfg, signal);
     return fn();
   }
 }
@@ -853,7 +853,7 @@ async function runWatcher(pi: any, ctx: any, cfg: ParleConfig, signal: AbortSign
   setStatus(ctx, cfg);
   try {
     await ensureBootstrapped(ctx, cfg, signal);
-    if (!runtime.baselineAt && !cfg.sessionHandleOverride?.value) await baselineResponsiveDelivery(ctx, cfg, signal);
+    if (!runtime.baselineAt && !cfg.sessionAlias?.value) await baselineResponsiveDelivery(ctx, cfg, signal);
     while (!signal.aborted && watcherConfigured(cfg)) {
       try {
         await maybeHeartbeatAgentSession(ctx, cfg, signal);
@@ -913,7 +913,7 @@ function statusDetails(ctx: any) {
     roomHandle: redactedValue(cfg.roomHandle),
     agentToken: redactedValue(cfg.agentToken),
     agentTokenId: redactedValue(cfg.agentTokenId),
-    sessionHandleOverride: redactedValue(cfg.sessionHandleOverride),
+    sessionAlias: redactedValue(cfg.sessionAlias),
     watchEnabled: redactedValue(cfg.watchEnabled),
     warnings: Array.from(new Set(cfg.warnings)),
     runtime: {

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -61,7 +61,7 @@ test("status bootstraps and redacts session handle", async () => {
   const cwd = tempProject("PARLE_ROOM_ID=room-1\nPARLE_ROOM_AGENT_TOKEN=token-1\n");
   globalThis.fetch = async (url) => {
     const u = String(url);
-    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-1", session_handle: "raw-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.raw-session" }), { status: 201 });
+    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-1", session_credential: "parle_ses_raw-session", session_handle: "raw-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.raw-session" }), { status: 201 });
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-1", room_id: "room-1", agent_session_id: "as-1" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 7, messages: [] }), { status: 200 });
     throw new Error("unexpected " + u);
@@ -94,7 +94,7 @@ test("parle_send includes direct addressing when to is present", async () => {
   let messageRequest;
   const harness = installSendHarness(async (url, init = {}) => {
     const u = String(url);
-    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-send", session_handle: "send-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.send-session" }), { status: 201 });
+    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-send", session_credential: "parle_ses_send-session", session_handle: "send-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.send-session" }), { status: 201 });
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-send" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
     if (u.endsWith("/v/rooms/room-send/messages")) {
@@ -173,7 +173,7 @@ test("parle_inbox reads the inbound attention surface", async () => {
   let inboxURL;
   const harness = installSendHarness(async (url) => {
     const u = String(url);
-    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-inbox", session_handle: "inbox-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.inbox-session" }), { status: 201 });
+    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-inbox", session_credential: "parle_ses_" + String("inbox-session"), session_handle: "inbox-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.inbox-session" }), { status: 201 });
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-inbox" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 3, messages: [] }), { status: 200 });
     if (u.includes("/inbound")) {
@@ -207,7 +207,7 @@ test("parle_affordances wraps the room affordances endpoint", async () => {
   let sawAffordances = false;
   const harness = installSendHarness(async (url) => {
     const u = String(url);
-    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-aff", session_handle: "aff-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.aff-session" }), { status: 201 });
+    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-aff", session_credential: "parle_ses_" + String("aff-session"), session_handle: "aff-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.aff-session" }), { status: 201 });
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-aff" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
     if (u.endsWith("/v/rooms/room-send/affordances")) {
@@ -240,7 +240,7 @@ test("wake hint drains responsive delivery without long polling", async () => {
   const harness = installSendHarness(async (url, init = {}) => {
     const u = String(url);
     requested.push(u);
-    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-wake", session_handle: "wake-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.wake-session" }), { status: 201 });
+    if (u.endsWith("/v/agent/sessions")) return new Response(JSON.stringify({ agent_session_id: "as-wake", session_credential: "parle_ses_" + String("wake-session"), session_handle: "wake-session", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.wake-session" }), { status: 201 });
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-wake" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
     if (u.includes("/responsive-delivery/ack")) {
@@ -275,7 +275,7 @@ test("heartbeat 404 reboots the session before the watcher can wedge", async () 
     const u = String(url);
     if (u.endsWith("/v/agent/sessions")) {
       sessionCreates += 1;
-      return new Response(JSON.stringify({ agent_session_id: `as-heart-${sessionCreates}`, session_handle: `heart-session-${sessionCreates}`, expires_at: "2026-07-04T00:00:00Z", address: `@p.a.heart-session-${sessionCreates}` }), { status: 201 });
+      return new Response(JSON.stringify({ agent_session_id: `as-heart-${sessionCreates}`, session_credential: `parle_ses_heart-session-${sessionCreates}`, session_handle: `heart-session-${sessionCreates}`, expires_at: "2026-07-04T00:00:00Z", address: `@p.a.heart-session-${sessionCreates}` }), { status: 201 });
     }
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-heart" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
@@ -304,7 +304,7 @@ test("room tool calls rebootstrap after session 404", async () => {
     const u = String(url);
     if (u.endsWith("/v/agent/sessions")) {
       sessionCreates += 1;
-      return new Response(JSON.stringify({ agent_session_id: `as-${sessionCreates}`, session_handle: `session-${sessionCreates}`, expires_at: "2026-07-04T00:00:00Z", address: `@p.a.session-${sessionCreates}` }), { status: 201 });
+      return new Response(JSON.stringify({ agent_session_id: `as-${sessionCreates}`, session_credential: `parle_ses_session-${sessionCreates}`, session_handle: `session-${sessionCreates}`, expires_at: "2026-07-04T00:00:00Z", address: `@p.a.session-${sessionCreates}` }), { status: 201 });
     }
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-reboot" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
@@ -331,7 +331,7 @@ test("mid-run unpinned rebootstrap baselines the new session before retry", asyn
     const u = String(url);
     if (u.endsWith("/v/agent/sessions")) {
       sessionCreates += 1;
-      return new Response(JSON.stringify({ agent_session_id: `as-baseline-${sessionCreates}`, session_handle: `baseline-session-${sessionCreates}`, expires_at: "2026-07-04T00:00:00Z", address: `@p.a.baseline-session-${sessionCreates}` }), { status: 201 });
+      return new Response(JSON.stringify({ agent_session_id: `as-baseline-${sessionCreates}`, session_credential: `parle_ses_baseline-session-${sessionCreates}`, session_handle: `baseline-session-${sessionCreates}`, expires_at: "2026-07-04T00:00:00Z", address: `@p.a.baseline-session-${sessionCreates}` }), { status: 201 });
     }
     if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-baseline" }), { status: 201 });
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });


### PR DESCRIPTION
Companion adapter changes for Parle core session credential hard cut.

Summary:
- default Parle-Version is 2026-07-07
- uses PARLE_SESSION_ALIAS instead of PARLE_SESSION_HANDLE
- stores and sends session_credential in Parle-Agent-Session
- redacts parle_ses_ credentials
- keeps alias optional with no .primary default
- rebuilds Claude plugin and desktop extension MCP artifacts

Validation:
- pnpm -r test
- pnpm typecheck
