### PR TITLE
Handle Parle terminal errors in adapters

### DIFF
--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -11201,9 +11201,9 @@ function assertNever(_x) {
 }
 function assert(_) {
 }
-function getEnumValues(entries) {
-  const numericValues = Object.values(entries).filter((v) => typeof v === "number");
-  const values = Object.entries(entries).filter(([k, _]) => numericValues.indexOf(+k) === -1).map(([_, v]) => v);
+function getEnumValues(entries2) {
+  const numericValues = Object.values(entries2).filter((v) => typeof v === "number");
+  const values = Object.entries(entries2).filter(([k, _]) => numericValues.indexOf(+k) === -1).map(([_, v]) => v);
   return values;
 }
 function joinValues(array2, separator = "|") {
@@ -21663,18 +21663,18 @@ function _set(Class2, valueType, params) {
 }
 // @__NO_SIDE_EFFECTS__
 function _enum(Class2, values, params) {
-  const entries = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
+  const entries2 = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
   return new Class2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...normalizeParams(params)
   });
 }
 // @__NO_SIDE_EFFECTS__
-function _nativeEnum(Class2, entries, params) {
+function _nativeEnum(Class2, entries2, params) {
   return new Class2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...normalizeParams(params)
   });
 }
@@ -24565,17 +24565,17 @@ var ZodEnum2 = /* @__PURE__ */ $constructor("ZodEnum", (inst, def) => {
   };
 });
 function _enum2(values, params) {
-  const entries = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
+  const entries2 = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
   return new ZodEnum2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...util_exports.normalizeParams(params)
   });
 }
-function nativeEnum(entries, params) {
+function nativeEnum(entries2, params) {
   return new ZodEnum2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...util_exports.normalizeParams(params)
   });
 }
@@ -31026,6 +31026,63 @@ function pruneRuntimeFiles(cwd, now = /* @__PURE__ */ new Date()) {
   }
 }
 
+// ../client/dist/error-contract.js
+var ERROR_ACTIONS = [
+  "retry",
+  "retry_with_backoff",
+  "backoff",
+  "rebootstrap",
+  "reauthorize",
+  "fix_client",
+  "stop"
+];
+var ERROR_SCOPES = [
+  "request",
+  "agent_token",
+  "agent_session",
+  "room_access",
+  "moderation",
+  "rate_limit",
+  "server"
+];
+function retryable(action) {
+  return action === "retry" || action === "retry_with_backoff" || action === "backoff";
+}
+var entries = {
+  malformed_request: { status: 400, action: "fix_client", scope: "request" },
+  unsupported_parle_version: { status: 400, action: "fix_client", scope: "request" },
+  payload_too_large: { status: 413, action: "fix_client", scope: "request" },
+  invalid_agent_token: { status: 401, action: "reauthorize", scope: "agent_token" },
+  invalid_agent_session: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_expired: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_ended: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_superseded: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  participant_revoked: { status: 403, action: "stop", scope: "room_access" },
+  room_not_found: { status: 404, action: "stop", scope: "room_access" },
+  agent_session_mismatch: { status: 404, action: "stop", scope: "agent_session" },
+  moderation_pending: { status: 409, action: "retry_with_backoff", scope: "moderation" },
+  address_not_deliverable: { status: 422, action: "stop", scope: "room_access" },
+  delivery_ack_rejected: { status: 409, action: "stop", scope: "request" },
+  rate_limited: { status: 429, action: "backoff", scope: "rate_limit" },
+  server_error: { status: 500, action: "retry_with_backoff", scope: "server" },
+  service_unavailable: { status: 503, action: "retry_with_backoff", scope: "server" },
+  moderation_saturated: { status: 503, action: "backoff", scope: "rate_limit" },
+  participant_held_cap: { status: 503, action: "backoff", scope: "rate_limit" },
+  idempotency_conflict: { status: 409, action: "stop", scope: "request" },
+  validation_failed: { status: 422, action: "fix_client", scope: "request" },
+  csrf_rejected: { status: 403, action: "fix_client", scope: "request" },
+  already_member: { status: 409, action: "stop", scope: "room_access" },
+  forbidden: { status: 403, action: "stop", scope: "room_access" },
+  token_quota_exceeded: { status: 403, action: "stop", scope: "agent_token" },
+  step_up_required: { status: 403, action: "stop", scope: "request" },
+  link_conflict: { status: 409, action: "stop", scope: "request" },
+  too_many_steps: { status: 422, action: "fix_client", scope: "request" },
+  moderation_config_too_large: { status: 422, action: "fix_client", scope: "request" },
+  cursor_gap: { status: 409, action: "retry", scope: "request" },
+  stream_reset: { status: 409, action: "retry_with_backoff", scope: "server" }
+};
+var ERROR_REGISTRY = Object.fromEntries(Object.entries(entries).map(([code, entry]) => [code, { ...entry, retryable: retryable(entry.action) }]));
+
 // ../client/dist/index.js
 var DEFAULT_API_BASE = "https://api.parle.sh";
 var DEFAULT_WAKE_BASE = DEFAULT_API_BASE;
@@ -31036,6 +31093,9 @@ var CONNECT_NEXT_GUIDANCE = "Report the session address and expiry, then arm res
 var ParleApiError = class extends Error {
   status;
   code;
+  action;
+  scope;
+  retryAfterMs;
   retryable;
   details;
   constructor(message, options = {}) {
@@ -31043,6 +31103,9 @@ var ParleApiError = class extends Error {
     this.name = "ParleApiError";
     this.status = options.status;
     this.code = options.code;
+    this.action = options.action;
+    this.scope = options.scope;
+    this.retryAfterMs = options.retryAfterMs;
     this.retryable = options.retryable ?? false;
     this.details = options.details;
   }
@@ -31111,6 +31174,97 @@ function parseJsonMaybe(text) {
   } catch {
     return {};
   }
+}
+function parseRetryAfterMs(header) {
+  if (!header)
+    return void 0;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0)
+    return Math.trunc(seconds * 1e3);
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs))
+    return Math.max(0, dateMs - Date.now());
+  return void 0;
+}
+function parseEnvelopeRetryAfterMs(errorObj, response) {
+  if (typeof errorObj?.retry_after_ms === "number" && Number.isFinite(errorObj.retry_after_ms) && errorObj.retry_after_ms >= 0)
+    return Math.trunc(errorObj.retry_after_ms);
+  if (typeof errorObj?.retry_after_seconds === "number" && Number.isFinite(errorObj.retry_after_seconds) && errorObj.retry_after_seconds >= 0)
+    return Math.trunc(errorObj.retry_after_seconds * 1e3);
+  return parseRetryAfterMs(response.headers.get("retry-after"));
+}
+function asErrorAction(value) {
+  return typeof value === "string" && ERROR_ACTIONS.includes(value) ? value : void 0;
+}
+function asErrorScope(value) {
+  return typeof value === "string" && ERROR_SCOPES.includes(value) ? value : void 0;
+}
+function defaultActionForStatus(status) {
+  if (status === 401)
+    return "reauthorize";
+  if (status === 429)
+    return "backoff";
+  if (status >= 500)
+    return "retry_with_backoff";
+  return "stop";
+}
+function defaultScopeForStatus(status) {
+  if (status === 401)
+    return "agent_token";
+  if (status === 429)
+    return "rate_limit";
+  if (status >= 500)
+    return "server";
+  return "request";
+}
+function actionRetryable(action) {
+  return action === "retry" || action === "retry_with_backoff" || action === "backoff";
+}
+var REQUEST_RETRY_ATTEMPTS = 5;
+var REQUEST_RETRY_WINDOW_MS = 6e4;
+function defaultSleep(ms, signal) {
+  return new Promise((resolve) => {
+    if (signal?.aborted || ms <= 0)
+      return resolve();
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+function retryDelayMs(error51, attempt) {
+  if (typeof error51.retryAfterMs === "number" && Number.isFinite(error51.retryAfterMs) && error51.retryAfterMs >= 0)
+    return Math.trunc(error51.retryAfterMs);
+  if (error51.action === "retry")
+    return 250;
+  const base = Math.min(1e4, 1e3 * 2 ** Math.max(0, attempt - 1));
+  return Math.trunc(base * (0.8 + Math.random() * 0.4));
+}
+function terminalStatusFor(error51) {
+  switch (error51.action) {
+    case "fix_client":
+      return "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+    case "reauthorize":
+      return "Parle stopped: agent token is invalid or revoked; reauthorize the agent.";
+    case "rebootstrap":
+      return "Parle stopped: agent session is dead; reconnect with parle_connect and re-arm.";
+    case "backoff":
+      return `Parle paused: retry scheduled after ${formatDuration(error51.retryAfterMs ?? 0)} (${error51.code || "backoff"}).`;
+    case "stop":
+      return error51.scope === "agent_session" ? "Parle stopped: agent session could not be rebootstrapped; reauthorize or restart." : "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+    default:
+      return error51.retryable ? `Parle paused: retry scheduled after ${formatDuration(error51.retryAfterMs ?? 0)}.` : "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+  }
+}
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0)
+    return "the server-provided delay";
+  if (ms < 1e3)
+    return `${ms}ms`;
+  const seconds = Math.ceil(ms / 1e3);
+  return seconds === 1 ? "1 second" : `${seconds} seconds`;
 }
 function redactString(input) {
   return input.replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>").replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>").replace(/(parle_(?:agt|inv|ses)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>").replace(/\bprt_[A-Za-z0-9_./+=:-]+/g, "prt_<redacted>").replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>").replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
@@ -31226,7 +31380,10 @@ var ParleAgentClient = class {
   fetchImpl;
   env;
   now;
+  sleepImpl;
   randomUUID;
+  clientName;
+  clientVersion;
   publishRuntime;
   runtime = {
     bootstrapped: false,
@@ -31241,6 +31398,7 @@ var ParleAgentClient = class {
   };
   bootstrapGeneration = 0;
   bootstrapInFlight = null;
+  rebootstrapEpisode = null;
   consecutiveBootstrapFailures = 0;
   unreadInFlight = false;
   unreadPollTimer = null;
@@ -31250,8 +31408,11 @@ var ParleAgentClient = class {
     this.cfg = resolveConfig(this.cwd, this.env);
     this.fetchImpl = options.fetch || fetch;
     this.now = options.now || (() => /* @__PURE__ */ new Date());
+    this.sleepImpl = options.sleep || defaultSleep;
     this.randomUUID = options.randomUUID || randomUUID;
     this.publishRuntime = options.publishRuntime;
+    this.clientName = options.clientName || options.publishRuntime?.adapterName || "@parlehq/agent-client";
+    this.clientVersion = options.clientVersion || options.publishRuntime?.adapterVersion;
     if (this.publishRuntime) {
       try {
         pruneRuntimeFiles(this.cwd, this.now());
@@ -31316,11 +31477,31 @@ var ParleAgentClient = class {
     assertSafeBase(this.cfg.wakeBase.value || this.cfg.apiBase.value || DEFAULT_WAKE_BASE, this.env);
   }
   async requestJson(pathOrUrl, options = {}) {
+    const method = options.method || (options.body === void 0 ? "GET" : "POST");
+    const retryableRequest = options.retry !== false && (method === "GET" || method === "HEAD" || Boolean(options.headers?.["Idempotency-Key"]));
+    const startedMs = this.now().getTime();
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await this.requestJsonOnce(pathOrUrl, options, method);
+      } catch (error51) {
+        if (!(error51 instanceof ParleApiError) || !retryableRequest || !error51.retryable || attempt >= REQUEST_RETRY_ATTEMPTS)
+          throw error51;
+        const elapsed = Math.max(0, this.now().getTime() - startedMs);
+        const delay = retryDelayMs(error51, attempt);
+        if (elapsed + delay > REQUEST_RETRY_WINDOW_MS)
+          throw error51;
+        await this.sleepImpl(delay, options.signal);
+      }
+    }
+  }
+  async requestJsonOnce(pathOrUrl, options, method) {
     const url2 = requestUrl(this.cfg, pathOrUrl);
     assertSafeBase(url2.origin, this.env);
     const headers = {
       Accept: "application/json",
       "Parle-Version": this.cfg.version.value || DEFAULT_VERSION,
+      "Parle-Client-Name": this.clientName,
+      ...this.clientVersion ? { "Parle-Client-Version": this.clientVersion } : {},
       ...options.headers
     };
     if (options.body !== void 0)
@@ -31338,11 +31519,11 @@ var ParleAgentClient = class {
     const signal = options.signal && timeout ? AbortSignal.any([options.signal, timeout]) : options.signal || timeout;
     let response;
     try {
-      response = await this.fetchImpl(url2, { method: options.method || (options.body === void 0 ? "GET" : "POST"), headers, body: options.body === void 0 ? void 0 : JSON.stringify(options.body), signal });
+      response = await this.fetchImpl(url2, { method, headers, body: options.body === void 0 ? void 0 : JSON.stringify(options.body), signal });
     } catch (error51) {
       const name = typeof error51?.name === "string" ? error51.name : "";
       if (name === "AbortError" || name === "TimeoutError" || signal?.aborted) {
-        throw new ParleApiError("Parle API request timed out or was aborted", { code: "timeout", retryable: true });
+        throw new ParleApiError("Parle API request timed out or was aborted", { code: "timeout", action: "retry_with_backoff", scope: "server", retryable: true });
       }
       throw error51;
     }
@@ -31352,15 +31533,21 @@ var ParleAgentClient = class {
     const json2 = parseJsonMaybe(options.rawResponse ? rawText : text);
     if (!response.ok) {
       const redactedJson = options.rawResponse ? parseJsonMaybe(text) : json2;
-      const code = redactedJson?.error?.code;
-      const msg = redactString(redactedJson?.error?.message || truncateText(text, 4096).text || response.statusText || `HTTP ${response.status}`);
+      const errorObj = redactedJson?.error && typeof redactedJson.error === "object" ? redactedJson.error : {};
+      const code = typeof errorObj.code === "string" ? errorObj.code : void 0;
+      const registry2 = code ? ERROR_REGISTRY[code] : void 0;
+      const action = asErrorAction(errorObj.action) || registry2?.action || defaultActionForStatus(response.status);
+      const scope = asErrorScope(errorObj.scope) || registry2?.scope || defaultScopeForStatus(response.status);
+      const retryAfterMs = parseEnvelopeRetryAfterMs(errorObj, response);
+      const retryable2 = typeof errorObj.retryable === "boolean" ? errorObj.retryable : actionRetryable(action);
+      const msg = redactString(errorObj.message || truncateText(text, 4096).text || response.statusText || `HTTP ${response.status}`);
       let message = `Parle API ${response.status}: ${msg}`;
-      if (response.status === 401) {
+      if (response.status === 401 && action === "reauthorize") {
         const hint = this.staleTokenHint();
         if (hint)
           message += ` ${hint}`;
       }
-      throw new ParleApiError(message, { status: response.status, code, retryable: response.status >= 500 || response.status === 429, details: redactedJson });
+      throw new ParleApiError(message, { status: response.status, code, action, scope, retryAfterMs, retryable: retryable2, details: redactedJson });
     }
     return json2;
   }
@@ -31429,6 +31616,13 @@ var ParleAgentClient = class {
   sessionExpired() {
     const expiry = this.runtime.expiresAt ? new Date(this.runtime.expiresAt) : null;
     return expiry !== null && !Number.isNaN(expiry.getTime()) && expiry <= this.now();
+  }
+  resetRebootstrapEpisodeIfHealthy() {
+    const episode = this.rebootstrapEpisode;
+    if (!episode?.healthySinceMs)
+      return;
+    if (this.now().getTime() - episode.healthySinceMs >= 10 * 6e4)
+      this.rebootstrapEpisode = null;
   }
   // Non-throwing bootstrap for eager startup and status auto-connect. Returns
   // whether a bootstrap was attempted. Skips when already live, unconfigured,
@@ -31525,7 +31719,7 @@ var ParleAgentClient = class {
     this.unreadInFlight = true;
     try {
       const sinceSeq = this.runtime.cursor || 0;
-      const response = await this.requestJson(`/v/rooms/${encodeURIComponent(this.cfg.roomId.value)}/inbound?since_seq=${encodeURIComponent(String(sinceSeq))}&wait=0`, { session: true, signal, timeoutMs: 1e4 });
+      const response = await this.requestJson(`/v/rooms/${encodeURIComponent(this.cfg.roomId.value)}/inbound?since_seq=${encodeURIComponent(String(sinceSeq))}&wait=0`, { session: true, signal, timeoutMs: 1e4, retry: false });
       if ((this.runtime.cursor || 0) !== sinceSeq)
         return;
       const rows = Array.isArray(response.messages) ? response.messages : [];
@@ -31612,13 +31806,38 @@ var ParleAgentClient = class {
     };
   }
   async withRebootstrap(fn, signal) {
+    this.resetRebootstrapEpisodeIfHealthy();
     await this.ensureBootstrapped(signal);
     try {
       return await fn();
     } catch (error51) {
-      if (error51?.status !== 401 && error51?.status !== 404)
+      if (!(error51 instanceof ParleApiError) || error51.action !== "rebootstrap")
         throw error51;
-      await this.bootstrap(signal, true);
+      const failedSessionHandle = this.runtime.sessionHandle || "<missing-session>";
+      const existing = this.rebootstrapEpisode;
+      if (existing?.failedSessionHandle === failedSessionHandle && (existing.attempted || existing.terminal)) {
+        if (this.bootstrapInFlight && !existing.terminal) {
+          await this.bootstrapInFlight;
+          return fn();
+        }
+        throw error51;
+      }
+      this.rebootstrapEpisode = { failedSessionHandle, attempted: true };
+      this.runtime.bootstrapped = false;
+      this.runtime.sessionHandle = "";
+      this.runtime.bootstrapState = "starting";
+      this.publishRuntimeState();
+      try {
+        await this.bootstrap(signal, true);
+        this.rebootstrapEpisode = { failedSessionHandle, attempted: true, healthySinceMs: this.now().getTime() };
+      } catch (bootstrapError) {
+        if (bootstrapError instanceof ParleApiError && ["fix_client", "reauthorize", "stop"].includes(bootstrapError.action || "")) {
+          this.rebootstrapEpisode = { failedSessionHandle, attempted: true, terminal: true };
+          this.runtime.lastBootstrapError = terminalStatusFor(bootstrapError);
+          this.publishRuntimeState();
+        }
+        throw bootstrapError;
+      }
       return fn();
     }
   }
@@ -31664,7 +31883,7 @@ var ParleAgentClient = class {
       }, signal);
     } catch (error51) {
       if (error51 instanceof ParleApiError) {
-        return { ok: false, retryable: error51.retryable, idempotencyKey: error51.retryable ? idempotencyKey : "<redacted>", addressedTo: params.to, warning: addressingWarning(params.body, params.to), error: redactString(error51.message) };
+        return { ok: false, retryable: error51.retryable, code: error51.code, action: error51.action, scope: error51.scope, retryAfterMs: error51.retryAfterMs, idempotencyKey: error51.retryable ? idempotencyKey : "<redacted>", addressedTo: params.to, warning: addressingWarning(params.body, params.to), error: redactString(error51.message) };
       }
       throw error51;
     }
@@ -31759,7 +31978,7 @@ function createParleMcpServer(client = new ParleAgentClient()) {
   return server;
 }
 async function runStdio() {
-  const client = new ParleAgentClient({ publishRuntime: { adapterName: "@parlehq/mcp-server" } });
+  const client = new ParleAgentClient({ publishRuntime: { adapterName: "@parlehq/mcp-server", adapterVersion: "0.0.0" } });
   const server = createParleMcpServer(client);
   installLifecycleHandlers(client);
   await server.connect(new StdioServerTransport());
@@ -31794,7 +32013,7 @@ async function safeTool(fn) {
   try {
     return toolResult(await fn());
   } catch (error51) {
-    const payload = error51 instanceof ParleApiError ? { ok: false, error: error51.message, code: error51.code, status: error51.status, retryable: error51.retryable } : { ok: false, error: error51 instanceof Error ? error51.message : String(error51) };
+    const payload = error51 instanceof ParleApiError ? { ok: false, error: error51.message, code: error51.code, status: error51.status, action: error51.action, scope: error51.scope, retryable: error51.retryable, retryAfterMs: error51.retryAfterMs } : { ok: false, error: error51 instanceof Error ? error51.message : String(error51) };
     return { ...toolResult(payload), isError: true };
   }
 }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+Terminal-error-aware client hard cut.
+
+- The shared client now parses Parle's canonical error envelope fields (`code`, `action`, `scope`, `retryable`, `retry_after_ms`) and exposes them on `ParleApiError` and MCP tool errors.
+- Live-session failures use `action=rebootstrap` and enter one single-flight rebootstrap episode instead of a generic 401 or 404 retry loop. A repeated terminal failure for the same dead session stops rather than minting indefinitely.
+- `parle-watch.sh` no longer uses `curl -f`; it preserves error bodies, honors terminal actions, respects retry delays for retryable errors, and prints redaction-safe stop statuses for missing config or terminal errors.
+
 ## 0.5.2 (2026-07-07)
 
 `parle-watch.sh` self-loads its configuration.

--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -39,13 +39,13 @@ node ${CLAUDE_PLUGIN_ROOT}/dist/parle-mcp.js
 
 Configure Parle with `PARLE_API_BASE`, `PARLE_VERSION`, `PARLE_ROOM_ID`, and `PARLE_ROOM_AGENT_TOKEN` in the Claude environment. `.mcp.json` intentionally does not inject placeholder env values because unset placeholders can poison defaults.
 
-Config sources resolve in strict precedence -- process environment, then `<cwd>/.env`, then `<cwd>/.parle/credentials` -- and load once at MCP server start. The plugin never writes these files. A token rotated on disk after launch does not take effect (and a stale process-env value shadows a corrected `.env`) until the Claude Code session restarts; since 0.3.1, 401 errors, `parle_setup`, and `parle_status` warn when the loaded token differs from the on-disk value.
+Config sources resolve in strict precedence -- process environment, then `<cwd>/.env`, then `<cwd>/.parle/credentials` -- and load once at MCP server start. The plugin never writes these files. A token rotated on disk after launch does not take effect (and a stale process-env value shadows a corrected `.env`) until the Claude Code session restarts; terminal `invalid_agent_token` / `reauthorize` errors, `parle_setup`, and `parle_status` warn when the loaded token differs from the on-disk value.
 
 Leave `PARLE_SESSION_ALIAS` unset for ordinary Claude sessions. Each process should normally use its generated ephemeral address. Set `PARLE_SESSION_ALIAS` only for a deliberately singleton named role because every new process with the same alias takes over that route and supersedes the previous session.
 
 ### Session lifecycle (0.4.0)
 
-When configured, the MCP server connects the room agent session eagerly at startup, so the session address exists before the first tool call. `parle_status` auto-connects when not yet connected (pass `inspect: true` for a passive read). The server also writes a display-safe runtime snapshot to `<cwd>/.parle/runtime/<pid>.json` for local UX surfaces; it never contains a credential. Add `.parle/runtime/` to `.gitignore` alongside `.parle/credentials`.
+When configured, the MCP server connects the room agent session eagerly at startup, so the session address exists before the first tool call. `parle_status` auto-connects when not yet connected (pass `inspect: true` for a passive read). Terminal live-session errors use the API's machine-readable `action=rebootstrap` contract and trigger one single-flight rebootstrap episode instead of a blind 401 loop. The server also writes a display-safe runtime snapshot to `<cwd>/.parle/runtime/<pid>.json` for local UX surfaces; it never contains a credential. Add `.parle/runtime/` to `.gitignore` alongside `.parle/credentials`.
 
 ### Statusline
 

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -11201,9 +11201,9 @@ function assertNever(_x) {
 }
 function assert(_) {
 }
-function getEnumValues(entries) {
-  const numericValues = Object.values(entries).filter((v) => typeof v === "number");
-  const values = Object.entries(entries).filter(([k, _]) => numericValues.indexOf(+k) === -1).map(([_, v]) => v);
+function getEnumValues(entries2) {
+  const numericValues = Object.values(entries2).filter((v) => typeof v === "number");
+  const values = Object.entries(entries2).filter(([k, _]) => numericValues.indexOf(+k) === -1).map(([_, v]) => v);
   return values;
 }
 function joinValues(array2, separator = "|") {
@@ -21663,18 +21663,18 @@ function _set(Class2, valueType, params) {
 }
 // @__NO_SIDE_EFFECTS__
 function _enum(Class2, values, params) {
-  const entries = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
+  const entries2 = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
   return new Class2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...normalizeParams(params)
   });
 }
 // @__NO_SIDE_EFFECTS__
-function _nativeEnum(Class2, entries, params) {
+function _nativeEnum(Class2, entries2, params) {
   return new Class2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...normalizeParams(params)
   });
 }
@@ -24565,17 +24565,17 @@ var ZodEnum2 = /* @__PURE__ */ $constructor("ZodEnum", (inst, def) => {
   };
 });
 function _enum2(values, params) {
-  const entries = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
+  const entries2 = Array.isArray(values) ? Object.fromEntries(values.map((v) => [v, v])) : values;
   return new ZodEnum2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...util_exports.normalizeParams(params)
   });
 }
-function nativeEnum(entries, params) {
+function nativeEnum(entries2, params) {
   return new ZodEnum2({
     type: "enum",
-    entries,
+    entries: entries2,
     ...util_exports.normalizeParams(params)
   });
 }
@@ -31026,6 +31026,63 @@ function pruneRuntimeFiles(cwd, now = /* @__PURE__ */ new Date()) {
   }
 }
 
+// ../client/dist/error-contract.js
+var ERROR_ACTIONS = [
+  "retry",
+  "retry_with_backoff",
+  "backoff",
+  "rebootstrap",
+  "reauthorize",
+  "fix_client",
+  "stop"
+];
+var ERROR_SCOPES = [
+  "request",
+  "agent_token",
+  "agent_session",
+  "room_access",
+  "moderation",
+  "rate_limit",
+  "server"
+];
+function retryable(action) {
+  return action === "retry" || action === "retry_with_backoff" || action === "backoff";
+}
+var entries = {
+  malformed_request: { status: 400, action: "fix_client", scope: "request" },
+  unsupported_parle_version: { status: 400, action: "fix_client", scope: "request" },
+  payload_too_large: { status: 413, action: "fix_client", scope: "request" },
+  invalid_agent_token: { status: 401, action: "reauthorize", scope: "agent_token" },
+  invalid_agent_session: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_expired: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_ended: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_superseded: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  participant_revoked: { status: 403, action: "stop", scope: "room_access" },
+  room_not_found: { status: 404, action: "stop", scope: "room_access" },
+  agent_session_mismatch: { status: 404, action: "stop", scope: "agent_session" },
+  moderation_pending: { status: 409, action: "retry_with_backoff", scope: "moderation" },
+  address_not_deliverable: { status: 422, action: "stop", scope: "room_access" },
+  delivery_ack_rejected: { status: 409, action: "stop", scope: "request" },
+  rate_limited: { status: 429, action: "backoff", scope: "rate_limit" },
+  server_error: { status: 500, action: "retry_with_backoff", scope: "server" },
+  service_unavailable: { status: 503, action: "retry_with_backoff", scope: "server" },
+  moderation_saturated: { status: 503, action: "backoff", scope: "rate_limit" },
+  participant_held_cap: { status: 503, action: "backoff", scope: "rate_limit" },
+  idempotency_conflict: { status: 409, action: "stop", scope: "request" },
+  validation_failed: { status: 422, action: "fix_client", scope: "request" },
+  csrf_rejected: { status: 403, action: "fix_client", scope: "request" },
+  already_member: { status: 409, action: "stop", scope: "room_access" },
+  forbidden: { status: 403, action: "stop", scope: "room_access" },
+  token_quota_exceeded: { status: 403, action: "stop", scope: "agent_token" },
+  step_up_required: { status: 403, action: "stop", scope: "request" },
+  link_conflict: { status: 409, action: "stop", scope: "request" },
+  too_many_steps: { status: 422, action: "fix_client", scope: "request" },
+  moderation_config_too_large: { status: 422, action: "fix_client", scope: "request" },
+  cursor_gap: { status: 409, action: "retry", scope: "request" },
+  stream_reset: { status: 409, action: "retry_with_backoff", scope: "server" }
+};
+var ERROR_REGISTRY = Object.fromEntries(Object.entries(entries).map(([code, entry]) => [code, { ...entry, retryable: retryable(entry.action) }]));
+
 // ../client/dist/index.js
 var DEFAULT_API_BASE = "https://api.parle.sh";
 var DEFAULT_WAKE_BASE = DEFAULT_API_BASE;
@@ -31036,6 +31093,9 @@ var CONNECT_NEXT_GUIDANCE = "Report the session address and expiry, then arm res
 var ParleApiError = class extends Error {
   status;
   code;
+  action;
+  scope;
+  retryAfterMs;
   retryable;
   details;
   constructor(message, options = {}) {
@@ -31043,6 +31103,9 @@ var ParleApiError = class extends Error {
     this.name = "ParleApiError";
     this.status = options.status;
     this.code = options.code;
+    this.action = options.action;
+    this.scope = options.scope;
+    this.retryAfterMs = options.retryAfterMs;
     this.retryable = options.retryable ?? false;
     this.details = options.details;
   }
@@ -31111,6 +31174,97 @@ function parseJsonMaybe(text) {
   } catch {
     return {};
   }
+}
+function parseRetryAfterMs(header) {
+  if (!header)
+    return void 0;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0)
+    return Math.trunc(seconds * 1e3);
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs))
+    return Math.max(0, dateMs - Date.now());
+  return void 0;
+}
+function parseEnvelopeRetryAfterMs(errorObj, response) {
+  if (typeof errorObj?.retry_after_ms === "number" && Number.isFinite(errorObj.retry_after_ms) && errorObj.retry_after_ms >= 0)
+    return Math.trunc(errorObj.retry_after_ms);
+  if (typeof errorObj?.retry_after_seconds === "number" && Number.isFinite(errorObj.retry_after_seconds) && errorObj.retry_after_seconds >= 0)
+    return Math.trunc(errorObj.retry_after_seconds * 1e3);
+  return parseRetryAfterMs(response.headers.get("retry-after"));
+}
+function asErrorAction(value) {
+  return typeof value === "string" && ERROR_ACTIONS.includes(value) ? value : void 0;
+}
+function asErrorScope(value) {
+  return typeof value === "string" && ERROR_SCOPES.includes(value) ? value : void 0;
+}
+function defaultActionForStatus(status) {
+  if (status === 401)
+    return "reauthorize";
+  if (status === 429)
+    return "backoff";
+  if (status >= 500)
+    return "retry_with_backoff";
+  return "stop";
+}
+function defaultScopeForStatus(status) {
+  if (status === 401)
+    return "agent_token";
+  if (status === 429)
+    return "rate_limit";
+  if (status >= 500)
+    return "server";
+  return "request";
+}
+function actionRetryable(action) {
+  return action === "retry" || action === "retry_with_backoff" || action === "backoff";
+}
+var REQUEST_RETRY_ATTEMPTS = 5;
+var REQUEST_RETRY_WINDOW_MS = 6e4;
+function defaultSleep(ms, signal) {
+  return new Promise((resolve) => {
+    if (signal?.aborted || ms <= 0)
+      return resolve();
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+function retryDelayMs(error51, attempt) {
+  if (typeof error51.retryAfterMs === "number" && Number.isFinite(error51.retryAfterMs) && error51.retryAfterMs >= 0)
+    return Math.trunc(error51.retryAfterMs);
+  if (error51.action === "retry")
+    return 250;
+  const base = Math.min(1e4, 1e3 * 2 ** Math.max(0, attempt - 1));
+  return Math.trunc(base * (0.8 + Math.random() * 0.4));
+}
+function terminalStatusFor(error51) {
+  switch (error51.action) {
+    case "fix_client":
+      return "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+    case "reauthorize":
+      return "Parle stopped: agent token is invalid or revoked; reauthorize the agent.";
+    case "rebootstrap":
+      return "Parle stopped: agent session is dead; reconnect with parle_connect and re-arm.";
+    case "backoff":
+      return `Parle paused: retry scheduled after ${formatDuration(error51.retryAfterMs ?? 0)} (${error51.code || "backoff"}).`;
+    case "stop":
+      return error51.scope === "agent_session" ? "Parle stopped: agent session could not be rebootstrapped; reauthorize or restart." : "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+    default:
+      return error51.retryable ? `Parle paused: retry scheduled after ${formatDuration(error51.retryAfterMs ?? 0)}.` : "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+  }
+}
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0)
+    return "the server-provided delay";
+  if (ms < 1e3)
+    return `${ms}ms`;
+  const seconds = Math.ceil(ms / 1e3);
+  return seconds === 1 ? "1 second" : `${seconds} seconds`;
 }
 function redactString(input) {
   return input.replace(/Bearer\s+[A-Za-z0-9_./+=:-]+/g, "Bearer <redacted>").replace(/(__Host-parle_session=)[^;\s]+/g, "$1<redacted>").replace(/(parle_(?:agt|inv|ses)_[A-Za-z0-9_./+=:-]+)/g, "<redacted-token>").replace(/\bprt_[A-Za-z0-9_./+=:-]+/g, "prt_<redacted>").replace(/(Idempotency-Key\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>").replace(/(Parle-Agent-Session\s*[:=]\s*)[A-Za-z0-9._:-]+/gi, "$1<redacted>");
@@ -31226,7 +31380,10 @@ var ParleAgentClient = class {
   fetchImpl;
   env;
   now;
+  sleepImpl;
   randomUUID;
+  clientName;
+  clientVersion;
   publishRuntime;
   runtime = {
     bootstrapped: false,
@@ -31241,6 +31398,7 @@ var ParleAgentClient = class {
   };
   bootstrapGeneration = 0;
   bootstrapInFlight = null;
+  rebootstrapEpisode = null;
   consecutiveBootstrapFailures = 0;
   unreadInFlight = false;
   unreadPollTimer = null;
@@ -31250,8 +31408,11 @@ var ParleAgentClient = class {
     this.cfg = resolveConfig(this.cwd, this.env);
     this.fetchImpl = options.fetch || fetch;
     this.now = options.now || (() => /* @__PURE__ */ new Date());
+    this.sleepImpl = options.sleep || defaultSleep;
     this.randomUUID = options.randomUUID || randomUUID;
     this.publishRuntime = options.publishRuntime;
+    this.clientName = options.clientName || options.publishRuntime?.adapterName || "@parlehq/agent-client";
+    this.clientVersion = options.clientVersion || options.publishRuntime?.adapterVersion;
     if (this.publishRuntime) {
       try {
         pruneRuntimeFiles(this.cwd, this.now());
@@ -31316,11 +31477,31 @@ var ParleAgentClient = class {
     assertSafeBase(this.cfg.wakeBase.value || this.cfg.apiBase.value || DEFAULT_WAKE_BASE, this.env);
   }
   async requestJson(pathOrUrl, options = {}) {
+    const method = options.method || (options.body === void 0 ? "GET" : "POST");
+    const retryableRequest = options.retry !== false && (method === "GET" || method === "HEAD" || Boolean(options.headers?.["Idempotency-Key"]));
+    const startedMs = this.now().getTime();
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await this.requestJsonOnce(pathOrUrl, options, method);
+      } catch (error51) {
+        if (!(error51 instanceof ParleApiError) || !retryableRequest || !error51.retryable || attempt >= REQUEST_RETRY_ATTEMPTS)
+          throw error51;
+        const elapsed = Math.max(0, this.now().getTime() - startedMs);
+        const delay = retryDelayMs(error51, attempt);
+        if (elapsed + delay > REQUEST_RETRY_WINDOW_MS)
+          throw error51;
+        await this.sleepImpl(delay, options.signal);
+      }
+    }
+  }
+  async requestJsonOnce(pathOrUrl, options, method) {
     const url2 = requestUrl(this.cfg, pathOrUrl);
     assertSafeBase(url2.origin, this.env);
     const headers = {
       Accept: "application/json",
       "Parle-Version": this.cfg.version.value || DEFAULT_VERSION,
+      "Parle-Client-Name": this.clientName,
+      ...this.clientVersion ? { "Parle-Client-Version": this.clientVersion } : {},
       ...options.headers
     };
     if (options.body !== void 0)
@@ -31338,11 +31519,11 @@ var ParleAgentClient = class {
     const signal = options.signal && timeout ? AbortSignal.any([options.signal, timeout]) : options.signal || timeout;
     let response;
     try {
-      response = await this.fetchImpl(url2, { method: options.method || (options.body === void 0 ? "GET" : "POST"), headers, body: options.body === void 0 ? void 0 : JSON.stringify(options.body), signal });
+      response = await this.fetchImpl(url2, { method, headers, body: options.body === void 0 ? void 0 : JSON.stringify(options.body), signal });
     } catch (error51) {
       const name = typeof error51?.name === "string" ? error51.name : "";
       if (name === "AbortError" || name === "TimeoutError" || signal?.aborted) {
-        throw new ParleApiError("Parle API request timed out or was aborted", { code: "timeout", retryable: true });
+        throw new ParleApiError("Parle API request timed out or was aborted", { code: "timeout", action: "retry_with_backoff", scope: "server", retryable: true });
       }
       throw error51;
     }
@@ -31352,15 +31533,21 @@ var ParleAgentClient = class {
     const json2 = parseJsonMaybe(options.rawResponse ? rawText : text);
     if (!response.ok) {
       const redactedJson = options.rawResponse ? parseJsonMaybe(text) : json2;
-      const code = redactedJson?.error?.code;
-      const msg = redactString(redactedJson?.error?.message || truncateText(text, 4096).text || response.statusText || `HTTP ${response.status}`);
+      const errorObj = redactedJson?.error && typeof redactedJson.error === "object" ? redactedJson.error : {};
+      const code = typeof errorObj.code === "string" ? errorObj.code : void 0;
+      const registry2 = code ? ERROR_REGISTRY[code] : void 0;
+      const action = asErrorAction(errorObj.action) || registry2?.action || defaultActionForStatus(response.status);
+      const scope = asErrorScope(errorObj.scope) || registry2?.scope || defaultScopeForStatus(response.status);
+      const retryAfterMs = parseEnvelopeRetryAfterMs(errorObj, response);
+      const retryable2 = typeof errorObj.retryable === "boolean" ? errorObj.retryable : actionRetryable(action);
+      const msg = redactString(errorObj.message || truncateText(text, 4096).text || response.statusText || `HTTP ${response.status}`);
       let message = `Parle API ${response.status}: ${msg}`;
-      if (response.status === 401) {
+      if (response.status === 401 && action === "reauthorize") {
         const hint = this.staleTokenHint();
         if (hint)
           message += ` ${hint}`;
       }
-      throw new ParleApiError(message, { status: response.status, code, retryable: response.status >= 500 || response.status === 429, details: redactedJson });
+      throw new ParleApiError(message, { status: response.status, code, action, scope, retryAfterMs, retryable: retryable2, details: redactedJson });
     }
     return json2;
   }
@@ -31429,6 +31616,13 @@ var ParleAgentClient = class {
   sessionExpired() {
     const expiry = this.runtime.expiresAt ? new Date(this.runtime.expiresAt) : null;
     return expiry !== null && !Number.isNaN(expiry.getTime()) && expiry <= this.now();
+  }
+  resetRebootstrapEpisodeIfHealthy() {
+    const episode = this.rebootstrapEpisode;
+    if (!episode?.healthySinceMs)
+      return;
+    if (this.now().getTime() - episode.healthySinceMs >= 10 * 6e4)
+      this.rebootstrapEpisode = null;
   }
   // Non-throwing bootstrap for eager startup and status auto-connect. Returns
   // whether a bootstrap was attempted. Skips when already live, unconfigured,
@@ -31525,7 +31719,7 @@ var ParleAgentClient = class {
     this.unreadInFlight = true;
     try {
       const sinceSeq = this.runtime.cursor || 0;
-      const response = await this.requestJson(`/v/rooms/${encodeURIComponent(this.cfg.roomId.value)}/inbound?since_seq=${encodeURIComponent(String(sinceSeq))}&wait=0`, { session: true, signal, timeoutMs: 1e4 });
+      const response = await this.requestJson(`/v/rooms/${encodeURIComponent(this.cfg.roomId.value)}/inbound?since_seq=${encodeURIComponent(String(sinceSeq))}&wait=0`, { session: true, signal, timeoutMs: 1e4, retry: false });
       if ((this.runtime.cursor || 0) !== sinceSeq)
         return;
       const rows = Array.isArray(response.messages) ? response.messages : [];
@@ -31612,13 +31806,38 @@ var ParleAgentClient = class {
     };
   }
   async withRebootstrap(fn, signal) {
+    this.resetRebootstrapEpisodeIfHealthy();
     await this.ensureBootstrapped(signal);
     try {
       return await fn();
     } catch (error51) {
-      if (error51?.status !== 401 && error51?.status !== 404)
+      if (!(error51 instanceof ParleApiError) || error51.action !== "rebootstrap")
         throw error51;
-      await this.bootstrap(signal, true);
+      const failedSessionHandle = this.runtime.sessionHandle || "<missing-session>";
+      const existing = this.rebootstrapEpisode;
+      if (existing?.failedSessionHandle === failedSessionHandle && (existing.attempted || existing.terminal)) {
+        if (this.bootstrapInFlight && !existing.terminal) {
+          await this.bootstrapInFlight;
+          return fn();
+        }
+        throw error51;
+      }
+      this.rebootstrapEpisode = { failedSessionHandle, attempted: true };
+      this.runtime.bootstrapped = false;
+      this.runtime.sessionHandle = "";
+      this.runtime.bootstrapState = "starting";
+      this.publishRuntimeState();
+      try {
+        await this.bootstrap(signal, true);
+        this.rebootstrapEpisode = { failedSessionHandle, attempted: true, healthySinceMs: this.now().getTime() };
+      } catch (bootstrapError) {
+        if (bootstrapError instanceof ParleApiError && ["fix_client", "reauthorize", "stop"].includes(bootstrapError.action || "")) {
+          this.rebootstrapEpisode = { failedSessionHandle, attempted: true, terminal: true };
+          this.runtime.lastBootstrapError = terminalStatusFor(bootstrapError);
+          this.publishRuntimeState();
+        }
+        throw bootstrapError;
+      }
       return fn();
     }
   }
@@ -31664,7 +31883,7 @@ var ParleAgentClient = class {
       }, signal);
     } catch (error51) {
       if (error51 instanceof ParleApiError) {
-        return { ok: false, retryable: error51.retryable, idempotencyKey: error51.retryable ? idempotencyKey : "<redacted>", addressedTo: params.to, warning: addressingWarning(params.body, params.to), error: redactString(error51.message) };
+        return { ok: false, retryable: error51.retryable, code: error51.code, action: error51.action, scope: error51.scope, retryAfterMs: error51.retryAfterMs, idempotencyKey: error51.retryable ? idempotencyKey : "<redacted>", addressedTo: params.to, warning: addressingWarning(params.body, params.to), error: redactString(error51.message) };
       }
       throw error51;
     }
@@ -31759,7 +31978,7 @@ function createParleMcpServer(client = new ParleAgentClient()) {
   return server;
 }
 async function runStdio() {
-  const client = new ParleAgentClient({ publishRuntime: { adapterName: "@parlehq/mcp-server" } });
+  const client = new ParleAgentClient({ publishRuntime: { adapterName: "@parlehq/mcp-server", adapterVersion: "0.0.0" } });
   const server = createParleMcpServer(client);
   installLifecycleHandlers(client);
   await server.connect(new StdioServerTransport());
@@ -31794,7 +32013,7 @@ async function safeTool(fn) {
   try {
     return toolResult(await fn());
   } catch (error51) {
-    const payload = error51 instanceof ParleApiError ? { ok: false, error: error51.message, code: error51.code, status: error51.status, retryable: error51.retryable } : { ok: false, error: error51 instanceof Error ? error51.message : String(error51) };
+    const payload = error51 instanceof ParleApiError ? { ok: false, error: error51.message, code: error51.code, status: error51.status, action: error51.action, scope: error51.scope, retryable: error51.retryable, retryAfterMs: error51.retryAfterMs } : { ok: false, error: error51 instanceof Error ? error51.message : String(error51) };
     return { ...toolResult(payload), isError: true };
   }
 }

--- a/packages/claude-plugin/skills/parle/SKILL.md
+++ b/packages/claude-plugin/skills/parle/SKILL.md
@@ -24,7 +24,7 @@ Source precedence and snapshot semantics:
 - Configuration loads ONCE when the MCP server process starts. Nothing re-reads it mid-session. The plugin never writes any of these files; `parle_setup` is diagnostic only.
 - Harness env injectors (for example mise `[env] _.file = ".env"`) snapshot `.env` into the process environment at shell init, which becomes the highest-precedence source.
 
-Token rotation procedure: after rotating `PARLE_ROOM_AGENT_TOKEN` (revoke old, mint new, update the secret store and `.env`), restart every consumer -- the Claude Code session (so the MCP server reloads config), any running `parle-watch.sh` (it inherits its launch env and will exit 2 after ten straight failures on a dead token), and any other harness holding the old snapshot. Symptom of a missed restart: a sudden bare `Parle API 401` mid-session; since 0.3.1 the error, `parle_setup`, and `parle_status` all warn when the loaded token differs from the on-disk value.
+Token rotation procedure: after rotating `PARLE_ROOM_AGENT_TOKEN` (revoke old, mint new, update the secret store and `.env`), restart every consumer -- the Claude Code session (so the MCP server reloads config), any running `parle-watch.sh`, and any other harness holding the old snapshot. A missed restart surfaces as a terminal `invalid_agent_token` / `reauthorize` error; the error, `parle_setup`, and `parle_status` all warn when the loaded token differs from the on-disk value.
 
 If tools are missing or setup fails, read `https://ai.parle.sh` and fall back to direct HTTP using `https://api.parle.sh/llms.txt`. Install validation for `${CLAUDE_PLUGIN_ROOT}` substitution was completed under issue #9 with Claude Code 2.1.201; see the plugin README for the observed flow.
 
@@ -54,9 +54,9 @@ Claude Code cannot receive Parle pushes today: MCP v1 has no background delivery
 
 1. Take the watermark from the `cursor` in your `parle_connect` result, or the latest `watermark` from a `parle_inbox`/`parle_send` result (`seq` of your own send counts).
 2. Take your agent session id from the `agentSessionId` in the `parle_connect` result, `parle_status` runtime, or the `session` block on the call that connected. It is room-visible operational metadata, not a credential (canonical classification: parlehq/parle#48).
-3. Start `${CLAUDE_PLUGIN_ROOT}/skills/parle/scripts/parle-watch.sh <watermark> <agent_session_id>` as a background Bash task, from the project directory. Since 0.5.2 the script self-loads missing `PARLE_*` config from `./.env` then `./.parle/credentials` (process env wins), so no `set -a` sourcing or env-injection wrapper is needed; it exits 2 immediately with a clear message when no config is found.
+3. Start `${CLAUDE_PLUGIN_ROOT}/skills/parle/scripts/parle-watch.sh <watermark> <agent_session_id>` as a background Bash task, from the project directory. The script self-loads missing `PARLE_*` config from `./.env` then `./.parle/credentials` (process env wins), so no `set -a` sourcing or env-injection wrapper is needed; it exits 2 immediately with a redaction-safe message when no config is found.
 4. The script holds one `projection?wait=25` long-poll at a time and exits 0 as soon as a row relevant to you lands: authored by someone else, and either room-wide or a direct addressed to your session. Rows you authored and other sessions' direct traffic are skipped silently, so busy multi-session rooms do not wake you for nothing. The background-task exit re-wakes your session: drain `parle_inbox`, act, then restart the watcher.
-5. Exit 2 means ten consecutive request failures; check connectivity and restart.
+5. Exit 2 means a terminal Parle error such as `fix_client`, `reauthorize`, or `rebootstrap`, missing host configuration, or an exhausted retry budget. Read the redaction-safe status, repair the cause, then restart.
 
 Caveats:
 

--- a/packages/claude-plugin/skills/parle/scripts/parle-watch.sh
+++ b/packages/claude-plugin/skills/parle/scripts/parle-watch.sh
@@ -15,7 +15,7 @@
 # any new room row wakes you (v1 behavior).
 #
 # Needs: PARLE_API_BASE, PARLE_ROOM_ID, PARLE_ROOM_AGENT_TOKEN, PARLE_VERSION
-# Exit:  0 = relevant activity past since_seq, 2 = repeated failures
+# Exit:  0 = relevant activity past since_seq, 2 = terminal or repeated failures
 #
 # Config self-loads from the same sources and precedence as the adapters
 # client: process env first, then ./.env, then ./.parle/credentials (relative
@@ -50,24 +50,71 @@ load_missing PARLE_VERSION
 : "${PARLE_API_BASE:=https://api.parle.sh}"
 : "${PARLE_VERSION:=2026-07-07}"
 if [ -z "${PARLE_ROOM_ID:-}" ] || [ -z "${PARLE_ROOM_AGENT_TOKEN:-}" ]; then
-  echo "parle-watch: PARLE_ROOM_ID / PARLE_ROOM_AGENT_TOKEN not found in env, ./.env, or ./.parle/credentials (run from the project directory)" >&2
+  echo "Parle stopped: required host configuration is missing. PARLE_ROOM_ID / PARLE_ROOM_AGENT_TOKEN not found in env, ./.env, or ./.parle/credentials (run from the project directory)" >&2
   exit 2
 fi
 
 fails=0
 while :; do
-  resp=$(curl -sf --max-time 40 \
+  tmp=$(mktemp "${TMPDIR:-/tmp}/parle-watch.XXXXXX") || exit 2
+  status=$(curl -sS --max-time 40 -o "$tmp" -w '%{http_code}' \
     "$PARLE_API_BASE/v/rooms/$PARLE_ROOM_ID/projection?since_seq=$since&wait=25" \
     -H "Authorization: Bearer $PARLE_ROOM_AGENT_TOKEN" \
-    -H "Parle-Version: $PARLE_VERSION") || resp=""
-  if [ -z "$resp" ]; then
-    fails=$((fails + 1))
-    if [ "$fails" -ge 10 ]; then
-      echo "parle-watch: $fails consecutive failures, giving up" >&2
-      exit 2
-    fi
-    sleep $((fails * 5))
-    continue
+    -H "Parle-Version: $PARLE_VERSION") || status="000"
+  resp=$(cat "$tmp")
+  rm -f "$tmp"
+  if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+    action=$(printf '%s' "$resp" | python3 -c '
+import json, sys
+try:
+    err = (json.load(sys.stdin).get("error") or {})
+except Exception:
+    err = {}
+print(err.get("action") or "network")
+print(err.get("code") or "")
+print(err.get("retry_after_ms") or "")
+')
+    err_action=$(printf '%s\n' "$action" | sed -n '1p')
+    err_code=$(printf '%s\n' "$action" | sed -n '2p')
+    retry_after_ms=$(printf '%s\n' "$action" | sed -n '3p')
+    case "$err_action" in
+      fix_client)
+        echo "Parle stopped: client request is invalid; upgrade or repair the adapter. ${err_code}" >&2
+        exit 2
+        ;;
+      reauthorize)
+        echo "Parle stopped: agent token is invalid or revoked; reauthorize the agent. ${err_code}" >&2
+        exit 2
+        ;;
+      rebootstrap)
+        echo "Parle stopped: agent session is dead; reconnect with parle_connect and re-arm. ${err_code}" >&2
+        exit 2
+        ;;
+      stop)
+        echo "Parle stopped: agent session could not be rebootstrapped; reauthorize or restart. ${err_code}" >&2
+        exit 2
+        ;;
+      backoff|retry_with_backoff|retry)
+        fails=$((fails + 1))
+        [ -n "$retry_after_ms" ] && sleep_secs=$(( (retry_after_ms + 999) / 1000 )) || sleep_secs=$((fails * 5))
+        if [ "$fails" -ge 5 ]; then
+          echo "parle-watch: retry budget exhausted after $fails failures" >&2
+          exit 2
+        fi
+        echo "Parle paused: retrying after ${sleep_secs}s (${err_code:-$err_action})." >&2
+        sleep "$sleep_secs"
+        continue
+        ;;
+      *)
+        fails=$((fails + 1))
+        if [ "$fails" -ge 5 ]; then
+          echo "parle-watch: $fails consecutive network failures, giving up" >&2
+          exit 2
+        fi
+        sleep $((fails * 5))
+        continue
+        ;;
+    esac
   fi
   fails=0
   out=$(printf '%s' "$resp" | python3 -c '

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -11,13 +11,13 @@ It owns:
 - configuration parsing and source provenance
 - redaction and truncation
 - safe Parle host validation
-- request helpers with injectable fetch
+- request helpers with injectable fetch and low-cardinality client identity headers
 - setup diagnostics and guidance fetches
-- session bootstrap, 401 and session-404 re-bootstrap, heartbeat, and best-effort session end primitives
+- session bootstrap, terminal-error-aware rebootstrap episodes, heartbeat, and best-effort session end primitives
 - projection read, inbound read, affordances fetch, send, direct addressing, shared cursor helpers, and idempotency helpers
 - wake SSE stream handling, responsive-delivery drain with `wait=0`, ack helpers, and delivery dedupe state
 - structured delivery and moderation state
-- typed errors for adapters to render safely
+- typed errors with canonical `code`, `action`, `scope`, `retryable`, and `retryAfterMs` fields for adapters to render safely
 
 It must not import Pi, Claude, MCP SDK, Claude Desktop bundle code, or GalexC-specific code.
 

--- a/packages/client/src/error-contract.ts
+++ b/packages/client/src/error-contract.ts
@@ -1,0 +1,71 @@
+export const ERROR_ACTIONS = [
+  "retry",
+  "retry_with_backoff",
+  "backoff",
+  "rebootstrap",
+  "reauthorize",
+  "fix_client",
+  "stop",
+] as const;
+
+export const ERROR_SCOPES = [
+  "request",
+  "agent_token",
+  "agent_session",
+  "room_access",
+  "moderation",
+  "rate_limit",
+  "server",
+] as const;
+
+export type ErrorAction = (typeof ERROR_ACTIONS)[number];
+export type ErrorScope = (typeof ERROR_SCOPES)[number];
+
+export type ErrorRegistryEntry = {
+  status: number;
+  action: ErrorAction;
+  scope: ErrorScope;
+  retryable: boolean;
+};
+
+function retryable(action: ErrorAction): boolean {
+  return action === "retry" || action === "retry_with_backoff" || action === "backoff";
+}
+
+const entries = {
+  malformed_request: { status: 400, action: "fix_client", scope: "request" },
+  unsupported_parle_version: { status: 400, action: "fix_client", scope: "request" },
+  payload_too_large: { status: 413, action: "fix_client", scope: "request" },
+  invalid_agent_token: { status: 401, action: "reauthorize", scope: "agent_token" },
+  invalid_agent_session: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_expired: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_ended: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  agent_session_superseded: { status: 401, action: "rebootstrap", scope: "agent_session" },
+  participant_revoked: { status: 403, action: "stop", scope: "room_access" },
+  room_not_found: { status: 404, action: "stop", scope: "room_access" },
+  agent_session_mismatch: { status: 404, action: "stop", scope: "agent_session" },
+  moderation_pending: { status: 409, action: "retry_with_backoff", scope: "moderation" },
+  address_not_deliverable: { status: 422, action: "stop", scope: "room_access" },
+  delivery_ack_rejected: { status: 409, action: "stop", scope: "request" },
+  rate_limited: { status: 429, action: "backoff", scope: "rate_limit" },
+  server_error: { status: 500, action: "retry_with_backoff", scope: "server" },
+  service_unavailable: { status: 503, action: "retry_with_backoff", scope: "server" },
+  moderation_saturated: { status: 503, action: "backoff", scope: "rate_limit" },
+  participant_held_cap: { status: 503, action: "backoff", scope: "rate_limit" },
+  idempotency_conflict: { status: 409, action: "stop", scope: "request" },
+  validation_failed: { status: 422, action: "fix_client", scope: "request" },
+  csrf_rejected: { status: 403, action: "fix_client", scope: "request" },
+  already_member: { status: 409, action: "stop", scope: "room_access" },
+  forbidden: { status: 403, action: "stop", scope: "room_access" },
+  token_quota_exceeded: { status: 403, action: "stop", scope: "agent_token" },
+  step_up_required: { status: 403, action: "stop", scope: "request" },
+  link_conflict: { status: 409, action: "stop", scope: "request" },
+  too_many_steps: { status: 422, action: "fix_client", scope: "request" },
+  moderation_config_too_large: { status: 422, action: "fix_client", scope: "request" },
+  cursor_gap: { status: 409, action: "retry", scope: "request" },
+  stream_reset: { status: 409, action: "retry_with_backoff", scope: "server" },
+} satisfies Record<string, Omit<ErrorRegistryEntry, "retryable">>;
+
+export const ERROR_REGISTRY: Record<string, ErrorRegistryEntry> = Object.fromEntries(
+  Object.entries(entries).map(([code, entry]) => [code, { ...entry, retryable: retryable(entry.action) }]),
+);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,8 +2,10 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { RUNTIME_SCHEMA_VERSION, processStartedAtIso, pruneRuntimeFiles, removeRuntimeFile, writeRuntimeFile } from "./runtime-file.js";
+import { ERROR_ACTIONS, ERROR_REGISTRY, ERROR_SCOPES, type ErrorAction, type ErrorScope } from "./error-contract.js";
 
 export * from "./runtime-file.js";
+export { ERROR_ACTIONS, ERROR_REGISTRY, ERROR_SCOPES, type ErrorAction, type ErrorScope } from "./error-contract.js";
 
 export const DEFAULT_API_BASE = "https://api.parle.sh";
 export const DEFAULT_WAKE_BASE = DEFAULT_API_BASE;
@@ -68,7 +70,10 @@ export type ClientOptions = {
   env?: Record<string, string | undefined>;
   fetch?: FetchLike;
   now?: () => Date;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   randomUUID?: () => string;
+  clientName?: string;
+  clientVersion?: string;
   // When set, the client publishes a display-safe per-pid runtime snapshot to
   // .parle/runtime/<pid>.json on every bootstrap state change (see runtime-file.ts)
   // and prunes provably stale sibling files at construction.
@@ -88,6 +93,7 @@ export type RequestOptions = {
   // is a parle_ses_ token that redactString would destroy). Never surface a
   // rawResponse payload; error paths stay redacted regardless.
   rawResponse?: boolean;
+  retry?: boolean;
 };
 
 export type ReadParams = {
@@ -136,14 +142,20 @@ export type SendDeliveryStatus = {
 export class ParleApiError extends Error {
   status?: number;
   code?: string;
+  action?: ErrorAction;
+  scope?: ErrorScope;
+  retryAfterMs?: number;
   retryable: boolean;
   details?: unknown;
 
-  constructor(message: string, options: { status?: number; code?: string; retryable?: boolean; details?: unknown } = {}) {
+  constructor(message: string, options: { status?: number; code?: string; action?: ErrorAction; scope?: ErrorScope; retryAfterMs?: number; retryable?: boolean; details?: unknown } = {}) {
     super(message);
     this.name = "ParleApiError";
     this.status = options.status;
     this.code = options.code;
+    this.action = options.action;
+    this.scope = options.scope;
+    this.retryAfterMs = options.retryAfterMs;
     this.retryable = options.retryable ?? false;
     this.details = options.details;
   }
@@ -211,6 +223,99 @@ function parseJsonMaybe(text: string): any {
   } catch {
     return {};
   }
+}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.trunc(seconds * 1000);
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  return undefined;
+}
+
+function parseEnvelopeRetryAfterMs(errorObj: any, response: Response): number | undefined {
+  if (typeof errorObj?.retry_after_ms === "number" && Number.isFinite(errorObj.retry_after_ms) && errorObj.retry_after_ms >= 0) return Math.trunc(errorObj.retry_after_ms);
+  if (typeof errorObj?.retry_after_seconds === "number" && Number.isFinite(errorObj.retry_after_seconds) && errorObj.retry_after_seconds >= 0) return Math.trunc(errorObj.retry_after_seconds * 1000);
+  return parseRetryAfterMs(response.headers.get("retry-after"));
+}
+
+function asErrorAction(value: unknown): ErrorAction | undefined {
+  return typeof value === "string" && (ERROR_ACTIONS as readonly string[]).includes(value) ? value as ErrorAction : undefined;
+}
+
+function asErrorScope(value: unknown): ErrorScope | undefined {
+  return typeof value === "string" && (ERROR_SCOPES as readonly string[]).includes(value) ? value as ErrorScope : undefined;
+}
+
+function defaultActionForStatus(status: number): ErrorAction {
+  if (status === 401) return "reauthorize";
+  if (status === 429) return "backoff";
+  if (status >= 500) return "retry_with_backoff";
+  return "stop";
+}
+
+function defaultScopeForStatus(status: number): ErrorScope {
+  if (status === 401) return "agent_token";
+  if (status === 429) return "rate_limit";
+  if (status >= 500) return "server";
+  return "request";
+}
+
+function actionRetryable(action: ErrorAction): boolean {
+  return action === "retry" || action === "retry_with_backoff" || action === "backoff";
+}
+
+const REQUEST_RETRY_ATTEMPTS = 5;
+const REQUEST_RETRY_WINDOW_MS = 60_000;
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted || ms <= 0) return resolve();
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+function retryDelayMs(error: ParleApiError, attempt: number): number {
+  if (typeof error.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs) && error.retryAfterMs >= 0) return Math.trunc(error.retryAfterMs);
+  if (error.action === "retry") return 250;
+  const base = Math.min(10_000, 1_000 * 2 ** Math.max(0, attempt - 1));
+  return Math.trunc(base * (0.8 + Math.random() * 0.4));
+}
+
+export function terminalStatusFor(error: ParleApiError): string {
+  switch (error.action) {
+    case "fix_client":
+      return "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+    case "reauthorize":
+      return "Parle stopped: agent token is invalid or revoked; reauthorize the agent.";
+    case "rebootstrap":
+      return "Parle stopped: agent session is dead; reconnect with parle_connect and re-arm.";
+    case "backoff":
+      return `Parle paused: retry scheduled after ${formatDuration(error.retryAfterMs ?? 0)} (${error.code || "backoff"}).`;
+    case "stop":
+      return error.scope === "agent_session"
+        ? "Parle stopped: agent session could not be rebootstrapped; reauthorize or restart."
+        : "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+    default:
+      return error.retryable ? `Parle paused: retry scheduled after ${formatDuration(error.retryAfterMs ?? 0)}.` : "Parle stopped: client request is invalid; upgrade or repair the adapter.";
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "the server-provided delay";
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.ceil(ms / 1000);
+  return seconds === 1 ? "1 second" : `${seconds} seconds`;
 }
 
 export function redactString(input: string): string {
@@ -376,7 +481,10 @@ export class ParleAgentClient {
   readonly fetchImpl: FetchLike;
   readonly env: Record<string, string | undefined>;
   readonly now: () => Date;
+  readonly sleepImpl: (ms: number, signal?: AbortSignal) => Promise<void>;
   readonly randomUUID: () => string;
+  readonly clientName: string;
+  readonly clientVersion?: string;
   readonly publishRuntime?: { adapterName: string; adapterVersion?: string };
   runtime: RuntimeState = {
     bootstrapped: false,
@@ -391,6 +499,7 @@ export class ParleAgentClient {
   };
   private bootstrapGeneration = 0;
   private bootstrapInFlight: Promise<RuntimeState> | null = null;
+  private rebootstrapEpisode: { failedSessionHandle: string; attempted: boolean; healthySinceMs?: number; terminal?: boolean } | null = null;
   private consecutiveBootstrapFailures = 0;
   private unreadInFlight = false;
   private unreadPollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -401,8 +510,11 @@ export class ParleAgentClient {
     this.cfg = resolveConfig(this.cwd, this.env);
     this.fetchImpl = options.fetch || fetch;
     this.now = options.now || (() => new Date());
+    this.sleepImpl = options.sleep || defaultSleep;
     this.randomUUID = options.randomUUID || randomUUID;
     this.publishRuntime = options.publishRuntime;
+    this.clientName = options.clientName || options.publishRuntime?.adapterName || "@parlehq/agent-client";
+    this.clientVersion = options.clientVersion || options.publishRuntime?.adapterVersion;
     if (this.publishRuntime) {
       try {
         pruneRuntimeFiles(this.cwd, this.now());
@@ -472,11 +584,30 @@ export class ParleAgentClient {
   }
 
   async requestJson(pathOrUrl: string, options: RequestOptions = {}): Promise<any> {
+    const method = options.method || (options.body === undefined ? "GET" : "POST");
+    const retryableRequest = options.retry !== false && (method === "GET" || method === "HEAD" || Boolean(options.headers?.["Idempotency-Key"]));
+    const startedMs = this.now().getTime();
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await this.requestJsonOnce(pathOrUrl, options, method);
+      } catch (error: any) {
+        if (!(error instanceof ParleApiError) || !retryableRequest || !error.retryable || attempt >= REQUEST_RETRY_ATTEMPTS) throw error;
+        const elapsed = Math.max(0, this.now().getTime() - startedMs);
+        const delay = retryDelayMs(error, attempt);
+        if (elapsed + delay > REQUEST_RETRY_WINDOW_MS) throw error;
+        await this.sleepImpl(delay, options.signal);
+      }
+    }
+  }
+
+  private async requestJsonOnce(pathOrUrl: string, options: RequestOptions, method: string): Promise<any> {
     const url = requestUrl(this.cfg, pathOrUrl);
     assertSafeBase(url.origin, this.env);
     const headers: Record<string, string> = {
       Accept: "application/json",
       "Parle-Version": this.cfg.version.value || DEFAULT_VERSION,
+      "Parle-Client-Name": this.clientName,
+      ...(this.clientVersion ? { "Parle-Client-Version": this.clientVersion } : {}),
       ...options.headers,
     };
     if (options.body !== undefined) headers["Content-Type"] = "application/json";
@@ -490,11 +621,11 @@ export class ParleAgentClient {
     const signal = options.signal && timeout ? AbortSignal.any([options.signal, timeout]) : options.signal || timeout;
     let response: Response;
     try {
-      response = await this.fetchImpl(url, { method: options.method || (options.body === undefined ? "GET" : "POST"), headers, body: options.body === undefined ? undefined : JSON.stringify(options.body), signal });
+      response = await this.fetchImpl(url, { method, headers, body: options.body === undefined ? undefined : JSON.stringify(options.body), signal });
     } catch (error: any) {
       const name = typeof error?.name === "string" ? error.name : "";
       if (name === "AbortError" || name === "TimeoutError" || signal?.aborted) {
-        throw new ParleApiError("Parle API request timed out or was aborted", { code: "timeout", retryable: true });
+        throw new ParleApiError("Parle API request timed out or was aborted", { code: "timeout", action: "retry_with_backoff", scope: "server", retryable: true });
       }
       throw error;
     }
@@ -504,16 +635,20 @@ export class ParleAgentClient {
     const json = parseJsonMaybe(options.rawResponse ? rawText : text);
     if (!response.ok) {
       const redactedJson = options.rawResponse ? parseJsonMaybe(text) : json;
-      const code = redactedJson?.error?.code;
-      const msg = redactString(redactedJson?.error?.message || truncateText(text, 4096).text || response.statusText || `HTTP ${response.status}`);
-      // @parle-interpretation parlehq/parle#431
-      // Replace status-class retry inference once API errors expose canonical retryability.
+      const errorObj = redactedJson?.error && typeof redactedJson.error === "object" ? redactedJson.error : {};
+      const code = typeof errorObj.code === "string" ? errorObj.code : undefined;
+      const registry = code ? ERROR_REGISTRY[code] : undefined;
+      const action = asErrorAction(errorObj.action) || registry?.action || defaultActionForStatus(response.status);
+      const scope = asErrorScope(errorObj.scope) || registry?.scope || defaultScopeForStatus(response.status);
+      const retryAfterMs = parseEnvelopeRetryAfterMs(errorObj, response);
+      const retryable = typeof errorObj.retryable === "boolean" ? errorObj.retryable : actionRetryable(action);
+      const msg = redactString(errorObj.message || truncateText(text, 4096).text || response.statusText || `HTTP ${response.status}`);
       let message = `Parle API ${response.status}: ${msg}`;
-      if (response.status === 401) {
+      if (response.status === 401 && action === "reauthorize") {
         const hint = this.staleTokenHint();
         if (hint) message += ` ${hint}`;
       }
-      throw new ParleApiError(message, { status: response.status, code, retryable: response.status >= 500 || response.status === 429, details: redactedJson });
+      throw new ParleApiError(message, { status: response.status, code, action, scope, retryAfterMs, retryable, details: redactedJson });
     }
     return json;
   }
@@ -584,6 +719,14 @@ export class ParleAgentClient {
   private sessionExpired(): boolean {
     const expiry = this.runtime.expiresAt ? new Date(this.runtime.expiresAt) : null;
     return expiry !== null && !Number.isNaN(expiry.getTime()) && expiry <= this.now();
+  }
+
+  private resetRebootstrapEpisodeIfHealthy(): void {
+    const episode = this.rebootstrapEpisode;
+    // A terminal session gets one repair attempt, then needs ten quiet minutes
+    // before a future failure can start a new episode.
+    if (!episode?.healthySinceMs) return;
+    if (this.now().getTime() - episode.healthySinceMs >= 10 * 60_000) this.rebootstrapEpisode = null;
   }
 
   // Non-throwing bootstrap for eager startup and status auto-connect. Returns
@@ -677,7 +820,7 @@ export class ParleAgentClient {
     this.unreadInFlight = true;
     try {
       const sinceSeq = this.runtime.cursor || 0;
-      const response = await this.requestJson(`/v/rooms/${encodeURIComponent(this.cfg.roomId!.value!)}/inbound?since_seq=${encodeURIComponent(String(sinceSeq))}&wait=0`, { session: true, signal, timeoutMs: 10_000 });
+      const response = await this.requestJson(`/v/rooms/${encodeURIComponent(this.cfg.roomId!.value!)}/inbound?since_seq=${encodeURIComponent(String(sinceSeq))}&wait=0`, { session: true, signal, timeoutMs: 10_000, retry: false });
       if ((this.runtime.cursor || 0) !== sinceSeq) return;
       const rows = Array.isArray(response.messages) ? response.messages : [];
       this.setUnread(rows.filter((row: any) => typeof row?.seq === "number" && row.seq > sinceSeq).length);
@@ -769,12 +912,39 @@ export class ParleAgentClient {
   }
 
   async withRebootstrap<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    this.resetRebootstrapEpisodeIfHealthy();
     await this.ensureBootstrapped(signal);
     try {
       return await fn();
     } catch (error: any) {
-      if (error?.status !== 401 && error?.status !== 404) throw error;
-      await this.bootstrap(signal, true);
+      if (!(error instanceof ParleApiError) || error.action !== "rebootstrap") throw error;
+      // Missing handles share one defensive bucket. In practice session terminal
+      // errors arrive only after a handle was presented.
+      const failedSessionHandle = this.runtime.sessionHandle || "<missing-session>";
+      const existing = this.rebootstrapEpisode;
+      if (existing?.failedSessionHandle === failedSessionHandle && (existing.attempted || existing.terminal)) {
+        if (this.bootstrapInFlight && !existing.terminal) {
+          await this.bootstrapInFlight;
+          return fn();
+        }
+        throw error;
+      }
+      this.rebootstrapEpisode = { failedSessionHandle, attempted: true };
+      this.runtime.bootstrapped = false;
+      this.runtime.sessionHandle = "";
+      this.runtime.bootstrapState = "starting";
+      this.publishRuntimeState();
+      try {
+        await this.bootstrap(signal, true);
+        this.rebootstrapEpisode = { failedSessionHandle, attempted: true, healthySinceMs: this.now().getTime() };
+      } catch (bootstrapError: any) {
+        if (bootstrapError instanceof ParleApiError && ["fix_client", "reauthorize", "stop"].includes(bootstrapError.action || "")) {
+          this.rebootstrapEpisode = { failedSessionHandle, attempted: true, terminal: true };
+          this.runtime.lastBootstrapError = terminalStatusFor(bootstrapError);
+          this.publishRuntimeState();
+        }
+        throw bootstrapError;
+      }
       return fn();
     }
   }
@@ -828,7 +998,7 @@ export class ParleAgentClient {
       }, signal);
     } catch (error: any) {
       if (error instanceof ParleApiError) {
-        return { ok: false, retryable: error.retryable, idempotencyKey: error.retryable ? idempotencyKey : "<redacted>", addressedTo: params.to, warning: addressingWarning(params.body, params.to), error: redactString(error.message) };
+        return { ok: false, retryable: error.retryable, code: error.code, action: error.action, scope: error.scope, retryAfterMs: error.retryAfterMs, idempotencyKey: error.retryable ? idempotencyKey : "<redacted>", addressedTo: params.to, warning: addressingWarning(params.body, params.to), error: redactString(error.message) };
       }
       throw error;
     }

--- a/packages/client/test/index.test.mjs
+++ b/packages/client/test/index.test.mjs
@@ -1,10 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { findForbiddenImports } from "../scripts/check-boundaries.mjs";
 import {
+  ERROR_ACTIONS,
+  ERROR_REGISTRY,
+  ERROR_SCOPES,
   ParleAgentClient,
   addressingWarning,
   assertSafeBase,
@@ -17,6 +20,7 @@ import {
   redactString,
   resolveConfig,
   summarizeSendDelivery,
+  terminalStatusFor,
   updateCursorFromMessages,
 } from "../dist/index.js";
 
@@ -116,6 +120,21 @@ test("wrapped content compacts only exact same-response framing", () => {
   assert.equal(compactServerWrappedContent(content, preamble, "ABC"), "«FENCE BEGIN ABC»\nhello\n«FENCE END ABC»");
   assert.equal(compactServerWrappedContent(content, "wrong", "ABC"), content);
   assert.equal(compactServerWrappedContent(content.replace("trusted\n", "trusted\n\n"), preamble, "ABC"), content.replace("trusted\n", "trusted\n\n"));
+});
+
+test("requestJson sends low-cardinality client identity headers", async () => {
+  let observed;
+  const client = new ParleAgentClient({
+    env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
+    publishRuntime: { adapterName: "@parlehq/test-adapter", adapterVersion: "1.2.3" },
+    fetch: async (_url, init = {}) => {
+      observed = init.headers;
+      return json({ ok: true });
+    },
+  });
+  await client.requestJson("/v/test");
+  assert.equal(observed["Parle-Client-Name"], "@parlehq/test-adapter");
+  assert.equal(observed["Parle-Client-Version"], "1.2.3");
 });
 
 test("requestJson validates absolute URLs before sending bearer tokens", async () => {
@@ -232,7 +251,7 @@ test("read cursor advances only through returned capped messages", async () => {
   assert.equal(result.cursorAfter, 4);
 });
 
-test("401 rebootstrap retries once and preserves cursor", async () => {
+test("agent-session rebootstrap retries once and preserves cursor", async () => {
   let sessions = 0;
   let readAttempts = 0;
   const client = new ParleAgentClient({
@@ -244,7 +263,7 @@ test("401 rebootstrap retries once and preserves cursor", async () => {
       if (u.includes("/projection?wait=0")) return json({ watermark: 12, messages: [] });
       if (u.includes("/projection?since_seq=")) {
         readAttempts += 1;
-        return json({ error: { code: "unauthorized", message: "expired" } }, 401);
+        return json({ error: { code: "invalid_agent_session", message: "expired", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }, 401);
       }
       return json({});
     },
@@ -255,7 +274,7 @@ test("401 rebootstrap retries once and preserves cursor", async () => {
   assert.equal(client.runtime.cursor, 12);
 });
 
-test("session 404 rebootstrap retries once and surfaces second 404", async () => {
+test("repeated agent-session terminal failure does not rebootstrap twice in one episode", async () => {
   let sessions = 0;
   let inboxAttempts = 0;
   const client = new ParleAgentClient({
@@ -267,18 +286,47 @@ test("session 404 rebootstrap retries once and surfaces second 404", async () =>
       if (u.includes("/projection?wait=0")) return json({ watermark: 21, messages: [] });
       if (u.includes("/inbound")) {
         inboxAttempts += 1;
-        return json({ error: { code: "session_not_found", message: "missing" } }, 404);
+        return json({ error: { code: "invalid_agent_session", message: "missing", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }, 401);
       }
       return json({});
     },
   });
-  await assert.rejects(() => client.readInbox(), { status: 404 });
+  await assert.rejects(() => client.readInbox(), { status: 401 });
   assert.equal(sessions, 2);
   assert.equal(inboxAttempts, 2);
   assert.equal(client.runtime.cursor, 21);
 });
 
-test("affordances rebootstrap after session 404 and preserve cursor", async () => {
+test("concurrent terminal failures share one rebootstrap flight", async () => {
+  let sessions = 0;
+  let inboxAttempts = 0;
+  const client = new ParleAgentClient({
+    env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
+    fetch: async (url) => {
+      const u = String(url);
+      if (u.endsWith("/v/agent/sessions")) {
+        sessions += 1;
+        if (sessions === 2) await new Promise((resolve) => setTimeout(resolve, 5));
+        return json({ agent_session_id: `as-${sessions}`, session_credential: `parle_ses_s${sessions}`, session_handle: `s${sessions}`, expires_at: "later" }, 201);
+      }
+      if (u.endsWith("/participants")) return json({ participant_id: "part-1" }, 201);
+      if (u.includes("/projection?wait=0")) return json({ watermark: 22, messages: [] });
+      if (u.includes("/inbound")) {
+        inboxAttempts += 1;
+        if (inboxAttempts <= 2) return json({ error: { code: "agent_session_ended", message: "ended", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }, 401);
+        return json({ watermark: 23, messages: [] });
+      }
+      return json({});
+    },
+  });
+  const [a, b] = await Promise.all([client.readInbox(), client.readInbox()]);
+  assert.equal(a.cursorAfter, 23);
+  assert.equal(b.cursorAfter, 23);
+  assert.equal(sessions, 2);
+  assert.equal(inboxAttempts, 4);
+});
+
+test("affordances rebootstrap after agent-session terminal error and preserve cursor", async () => {
   let sessions = 0;
   let affordanceAttempts = 0;
   const client = new ParleAgentClient({
@@ -290,7 +338,7 @@ test("affordances rebootstrap after session 404 and preserve cursor", async () =
       if (u.includes("/projection?wait=0")) return json({ watermark: 33, messages: [] });
       if (u.includes("/affordances")) {
         affordanceAttempts += 1;
-        if (affordanceAttempts === 1) return json({ error: { code: "session_not_found", message: "missing" } }, 404);
+        if (affordanceAttempts === 1) return json({ error: { code: "agent_session_expired", message: "missing", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }, 401);
         return json({ affordances: [{ action: "send" }] });
       }
       return json({});
@@ -303,7 +351,7 @@ test("affordances rebootstrap after session 404 and preserve cursor", async () =
   assert.equal(client.runtime.cursor, 33);
 });
 
-test("send reuses generated idempotency key across session 404 rebootstrap", async () => {
+test("send reuses generated idempotency key across agent-session rebootstrap", async () => {
   let sessions = 0;
   let messageAttempts = 0;
   const messageKeys = [];
@@ -318,7 +366,7 @@ test("send reuses generated idempotency key across session 404 rebootstrap", asy
       if (u.includes("/messages")) {
         messageAttempts += 1;
         messageKeys.push(init.headers["Idempotency-Key"]);
-        if (messageAttempts === 1) return json({ error: { code: "session_not_found", message: "missing" } }, 404);
+        if (messageAttempts === 1) return json({ error: { code: "agent_session_superseded", message: "missing", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }, 401);
         return json({ event_id: "evt-1", seq: 45 }, 201);
       }
       return json({});
@@ -343,12 +391,68 @@ test("send maps bootstrap setup errors into structured send failure", async () =
   assert.match(result.error, /PARLE_ROOM_AGENT_TOKEN is missing/);
 });
 
+test("shared error contract fixture matches vendored server registry snapshot", () => {
+  const golden = JSON.parse(readFileSync(new URL("../testdata/error-registry.golden.json", import.meta.url), "utf8"));
+  // Refresh after server registry changes by copying /openapi.json default error
+  // enum fields and internal/roomhttp/error_contract.go mappings into this file.
+  assert.deepEqual(ERROR_ACTIONS, golden.actions);
+  assert.deepEqual(ERROR_SCOPES, golden.scopes);
+  assert.deepEqual(ERROR_REGISTRY, golden.registry);
+});
+
+test("requestJson parses canonical error envelope action scope and retry delay", async () => {
+  const client = new ParleAgentClient({
+    env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
+    fetch: async () => json({ error: { code: "rate_limited", message: "slow down", action: "backoff", retryable: true, scope: "rate_limit", retry_after_ms: 2500 } }, 429),
+  });
+  await assert.rejects(() => client.requestJson("/v/test", { retry: false }), (error) => {
+    assert.equal(error.code, "rate_limited");
+    assert.equal(error.action, "backoff");
+    assert.equal(error.scope, "rate_limit");
+    assert.equal(error.retryable, true);
+    assert.equal(error.retryAfterMs, 2500);
+    assert.match(terminalStatusFor(error), /retry scheduled after 3 seconds/);
+    return true;
+  });
+});
+
+test("requestJson uses Retry-After header when retry_after_ms is absent", async () => {
+  const client = new ParleAgentClient({
+    env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
+    fetch: async () => new Response(JSON.stringify({ error: { code: "rate_limited", message: "slow down", action: "backoff", retryable: true, scope: "rate_limit", retry_after_ms: null } }), { status: 429, headers: { "content-type": "application/json", "retry-after": "4" } }),
+  });
+  await assert.rejects(() => client.requestJson("/v/test", { retry: false }), (error) => {
+    assert.equal(error.retryAfterMs, 4000);
+    return true;
+  });
+});
+
+test("requestJson honors Retry-After before retrying retryable GET failures", async () => {
+  let attempts = 0;
+  const sleeps = [];
+  const client = new ParleAgentClient({
+    env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
+    fetch: async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response(JSON.stringify({ error: { code: "rate_limited", message: "slow down", action: "backoff", retryable: true, scope: "rate_limit", retry_after_ms: null } }), { status: 429, headers: { "content-type": "application/json", "retry-after": "2" } });
+      }
+      return json({ ok: true });
+    },
+    sleep: async (ms) => { sleeps.push(ms); },
+  });
+  const result = await client.requestJson("/v/test");
+  assert.deepEqual(result, { ok: true });
+  assert.equal(attempts, 2);
+  assert.deepEqual(sleeps, [2000]);
+});
+
 test("requestJson wraps fetch timeout as retryable ParleApiError", async () => {
   const client = new ParleAgentClient({
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     fetch: async () => { throw new DOMException("timed out", "TimeoutError"); },
   });
-  await assert.rejects(() => client.requestJson("/v/test"), (error) => {
+  await assert.rejects(() => client.requestJson("/v/test", { retry: false }), (error) => {
     assert.equal(error.name, "ParleApiError");
     assert.equal(error.code, "timeout");
     assert.equal(error.retryable, true);
@@ -360,6 +464,7 @@ test("retryable send errors return idempotency key for byte-identical retry", as
   const client = new ParleAgentClient({
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token" },
     randomUUID: () => "idem-retry",
+    sleep: async () => {},
     fetch: async (url) => {
       const u = String(url);
       if (u.endsWith("/v/agent/sessions")) return json({ agent_session_id: "as-1", session_credential: "parle_ses_" + String("s1"), session_handle: "s1", expires_at: "later" }, 201);

--- a/packages/client/testdata/error-registry.golden.json
+++ b/packages/client/testdata/error-registry.golden.json
@@ -1,0 +1,53 @@
+{
+  "actions": [
+    "retry",
+    "retry_with_backoff",
+    "backoff",
+    "rebootstrap",
+    "reauthorize",
+    "fix_client",
+    "stop"
+  ],
+  "scopes": [
+    "request",
+    "agent_token",
+    "agent_session",
+    "room_access",
+    "moderation",
+    "rate_limit",
+    "server"
+  ],
+  "registry": {
+    "address_not_deliverable": { "status": 422, "action": "stop", "scope": "room_access", "retryable": false },
+    "agent_session_ended": { "status": 401, "action": "rebootstrap", "scope": "agent_session", "retryable": false },
+    "agent_session_expired": { "status": 401, "action": "rebootstrap", "scope": "agent_session", "retryable": false },
+    "agent_session_mismatch": { "status": 404, "action": "stop", "scope": "agent_session", "retryable": false },
+    "agent_session_superseded": { "status": 401, "action": "rebootstrap", "scope": "agent_session", "retryable": false },
+    "already_member": { "status": 409, "action": "stop", "scope": "room_access", "retryable": false },
+    "csrf_rejected": { "status": 403, "action": "fix_client", "scope": "request", "retryable": false },
+    "cursor_gap": { "status": 409, "action": "retry", "scope": "request", "retryable": true },
+    "delivery_ack_rejected": { "status": 409, "action": "stop", "scope": "request", "retryable": false },
+    "forbidden": { "status": 403, "action": "stop", "scope": "room_access", "retryable": false },
+    "idempotency_conflict": { "status": 409, "action": "stop", "scope": "request", "retryable": false },
+    "invalid_agent_session": { "status": 401, "action": "rebootstrap", "scope": "agent_session", "retryable": false },
+    "invalid_agent_token": { "status": 401, "action": "reauthorize", "scope": "agent_token", "retryable": false },
+    "link_conflict": { "status": 409, "action": "stop", "scope": "request", "retryable": false },
+    "malformed_request": { "status": 400, "action": "fix_client", "scope": "request", "retryable": false },
+    "moderation_config_too_large": { "status": 422, "action": "fix_client", "scope": "request", "retryable": false },
+    "moderation_pending": { "status": 409, "action": "retry_with_backoff", "scope": "moderation", "retryable": true },
+    "moderation_saturated": { "status": 503, "action": "backoff", "scope": "rate_limit", "retryable": true },
+    "participant_held_cap": { "status": 503, "action": "backoff", "scope": "rate_limit", "retryable": true },
+    "participant_revoked": { "status": 403, "action": "stop", "scope": "room_access", "retryable": false },
+    "payload_too_large": { "status": 413, "action": "fix_client", "scope": "request", "retryable": false },
+    "rate_limited": { "status": 429, "action": "backoff", "scope": "rate_limit", "retryable": true },
+    "room_not_found": { "status": 404, "action": "stop", "scope": "room_access", "retryable": false },
+    "server_error": { "status": 500, "action": "retry_with_backoff", "scope": "server", "retryable": true },
+    "service_unavailable": { "status": 503, "action": "retry_with_backoff", "scope": "server", "retryable": true },
+    "step_up_required": { "status": 403, "action": "stop", "scope": "request", "retryable": false },
+    "stream_reset": { "status": 409, "action": "retry_with_backoff", "scope": "server", "retryable": true },
+    "token_quota_exceeded": { "status": 403, "action": "stop", "scope": "agent_token", "retryable": false },
+    "too_many_steps": { "status": 422, "action": "fix_client", "scope": "request", "retryable": false },
+    "unsupported_parle_version": { "status": 400, "action": "fix_client", "scope": "request", "retryable": false },
+    "validation_failed": { "status": 422, "action": "fix_client", "scope": "request", "retryable": false }
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -110,7 +110,7 @@ export function createParleMcpServer(client: ParleMcpClientLike = new ParleAgent
 }
 
 export async function runStdio() {
-  const client = new ParleAgentClient({ publishRuntime: { adapterName: "@parlehq/mcp-server" } });
+  const client = new ParleAgentClient({ publishRuntime: { adapterName: "@parlehq/mcp-server", adapterVersion: "0.0.0" } });
   const server = createParleMcpServer(client);
   installLifecycleHandlers(client);
   await server.connect(new StdioServerTransport());
@@ -154,7 +154,7 @@ async function safeTool(fn: () => Promise<unknown>): Promise<any> {
     return toolResult(await fn());
   } catch (error: any) {
     const payload = error instanceof ParleApiError
-      ? { ok: false, error: error.message, code: error.code, status: error.status, retryable: error.retryable }
+      ? { ok: false, error: error.message, code: error.code, status: error.status, action: error.action, scope: error.scope, retryable: error.retryable, retryAfterMs: error.retryAfterMs }
       : { ok: false, error: error instanceof Error ? error.message : String(error) };
     return { ...toolResult(payload), isError: true };
   }


### PR DESCRIPTION
## Summary
- consume the Parle terminal error envelope in the shared agent client
- bound retries to safe requests and honor retry_after_ms / Retry-After
- make MCP, Claude plugin, desktop extension, and parle-watch.sh surface terminal actions without retry spam
- add low-cardinality client identity headers and a vendored server error-registry golden

## Validation
- pnpm typecheck
- pnpm --workspace-concurrency=1 -r test
- pnpm -F @parlehq/mcp-server build
- pnpm -F @parlehq/claude-plugin build
- pnpm -F @parlehq/claude-desktop-extension build
- sh -n packages/claude-plugin/skills/parle/scripts/parle-watch.sh
- git diff --check

Related: https://git.parle.dev/parlehq/parle/issues/443 and https://git.parle.dev/parlehq/parle/pulls/445. Closes #18.
