### PR TITLE
fix: stop Pi watcher on terminal API errors

### DIFF
--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -4,6 +4,15 @@ import { chmodSync as chmodSync2, existsSync as existsSync4, lstatSync as lstatS
 import { basename as basename2, dirname as dirname4, join as join4 } from "node:path";
 
 // ../client/dist/error-contract.js
+var ERROR_ACTIONS = [
+  "retry",
+  "retry_with_backoff",
+  "backoff",
+  "rebootstrap",
+  "reauthorize",
+  "fix_client",
+  "stop"
+];
 function retryable(action) {
   return action === "retry" || action === "retry_with_backoff" || action === "backoff";
 }
@@ -1999,7 +2008,7 @@ function summarizeSendDelivery(details) {
 // src/index.ts
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
-var PI_EXTENSION_VERSION = "0.1.28";
+var PI_EXTENSION_VERSION = "0.1.29";
 var RUNTIME_SCHEMA_VERSION2 = 1;
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";
@@ -2723,6 +2732,8 @@ async function requestJson(cfg, path, options = {}, state = runtime) {
   const headers = {
     Accept: "application/json",
     "Parle-Version": cfg.version.value || DEFAULT_VERSION,
+    "Parle-Client-Name": "@parlehq/pi-extension",
+    "Parle-Client-Version": PI_EXTENSION_VERSION,
     Authorization: `Bearer ${cfg.agentToken.value}`
   };
   if (options.session && state.sessionHandle) headers["Parle-Agent-Session"] = state.sessionHandle;
@@ -2754,10 +2765,21 @@ async function requestJson(cfg, path, options = {}, state = runtime) {
     const json = parseJsonMaybe(text);
     if (!response.ok) {
       const errorObj = json?.error && typeof json.error === "object" ? json.error : {};
+      const code = typeof errorObj.code === "string" ? errorObj.code : void 0;
+      const registry = code ? ERROR_REGISTRY[code] : void 0;
+      const action = typeof errorObj.action === "string" && ERROR_ACTIONS.includes(errorObj.action) ? errorObj.action : registry?.action;
+      const retryAfterHeader = response.headers.get("retry-after");
+      const retryAfterSeconds = retryAfterHeader ? Number(retryAfterHeader) : Number.NaN;
+      const retryAfterMs = typeof errorObj.retry_after_ms === "number" && Number.isFinite(errorObj.retry_after_ms) ? Math.max(0, Math.trunc(errorObj.retry_after_ms)) : Number.isFinite(retryAfterSeconds) ? Math.max(0, Math.trunc(retryAfterSeconds * 1e3)) : void 0;
       const msg = redactString(errorObj.message || truncateText(redactString(text), 4096).text);
-      const versionHint = response.status === 400 && /version/i.test(`${errorObj.code || ""} ${msg}`) ? formatVersionErrorHint(cfg, errorObj) : "";
+      const versionHint = response.status === 400 && /version/i.test(`${code || ""} ${msg}`) ? formatVersionErrorHint(cfg, errorObj) : "";
       const err = new Error(`Parle API ${response.status}: ${msg}${versionHint}`);
       err.status = response.status;
+      err.code = code;
+      err.action = action;
+      err.scope = typeof errorObj.scope === "string" ? errorObj.scope : registry?.scope;
+      err.retryable = typeof errorObj.retryable === "boolean" ? errorObj.retryable : registry?.retryable;
+      err.retryAfterMs = retryAfterMs;
       throw err;
     }
     return json ?? {};
@@ -3028,7 +3050,7 @@ async function withRebootstrap(ctx, cfg, fn, signal) {
   try {
     return await fn();
   } catch (error) {
-    if (error?.status !== 401 && error?.status !== 404) throw error;
+    if (error?.action !== "rebootstrap") throw error;
     const hadBaseline = Boolean(runtime.baselineAt);
     await bootstrap(ctx, cfg, signal, true);
     if (hadBaseline && !cfg.sessionAlias?.value) await baselineResponsiveDelivery(ctx, cfg, signal);
@@ -3266,6 +3288,14 @@ function recordWatcherError(error) {
   runtime.consecutiveWatcherFailures = (runtime.consecutiveWatcherFailures || 0) + 1;
   runtime.watcherBackoffCount = (runtime.watcherBackoffCount || 0) + 1;
 }
+function terminalWatcherState(error) {
+  if (error?.action === "reauthorize") return "auth_expired";
+  if (error?.action === "stop" || error?.action === "fix_client") return "disconnected";
+  return void 0;
+}
+function watcherRetryDelayMs(error) {
+  return typeof error?.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs) ? Math.max(0, Math.trunc(error.retryAfterMs)) : jitteredBackoffMs();
+}
 function isPiIdle(ctx) {
   return typeof ctx?.isIdle === "function" ? ctx.isIdle() : true;
 }
@@ -3361,15 +3391,17 @@ async function runWatcher(pi, ctx, cfg, signal, runId) {
       } catch (error) {
         if (signal.aborted) break;
         recordWatcherError(error);
-        runtime.watcherState = error?.status === 401 ? "auth_expired" : error?.status === 404 ? "session_expired" : "backoff";
+        const terminalState = terminalWatcherState(error);
+        runtime.watcherState = terminalState || (error?.action === "rebootstrap" ? "session_expired" : "backoff");
         setStatus(ctx, cfg);
-        await sleep(jitteredBackoffMs(), signal).catch(() => void 0);
+        if (terminalState) break;
+        await sleep(watcherRetryDelayMs(error), signal).catch(() => void 0);
       }
     }
   } catch (error) {
     if (!signal.aborted) {
       recordWatcherError(error);
-      runtime.watcherState = error?.status === 401 ? "auth_expired" : error?.status === 404 ? "session_expired" : "backoff";
+      runtime.watcherState = terminalWatcherState(error) || (error?.action === "rebootstrap" ? "session_expired" : "backoff");
       setStatus(ctx, cfg);
     }
   } finally {
@@ -3377,7 +3409,7 @@ async function runWatcher(pi, ctx, cfg, signal, runId) {
       watcherLoopRunning = false;
       if (signal.aborted) {
         runtime.watcherState = "disconnected";
-      } else if (runtime.watcherState !== "auth_expired" && runtime.watcherState !== "session_expired" && runtime.watcherState !== "backoff") {
+      } else if (runtime.watcherState !== "auth_expired" && runtime.watcherState !== "session_expired" && runtime.watcherState !== "backoff" && runtime.watcherState !== "disconnected") {
         runtime.watcherState = "off";
       }
       setStatus(ctx, cfg);
@@ -3505,6 +3537,8 @@ var __testing = {
   inboundPrompt,
   summarizeSendDelivery,
   maybeHeartbeatAgentSession,
+  terminalWatcherState,
+  watcherRetryDelayMs,
   startWatcher,
   handleWakeHint,
   queueResponsiveMessages,

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -2,10 +2,10 @@ import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { DEFAULT_API_BASE, DEFAULT_VERSION, ParleAccountClient, catalogGitExposureWarning, loadProfile, formatVersionErrorHint, parseKeyValueFile, parseProfiles, performProfileSwitch, profileCatalogHasProfile, redactString, resolveProfileCatalogPath, summarizeSendDelivery, type AcceptRoomInvitationParams, type ClaimPrincipalInviteParams, type ConnectOwnAgentParams, type CredentialProfile, type HardenAccountParams, type MintPrincipalInviteParams } from "@parlehq/agent-client";
+import { DEFAULT_API_BASE, DEFAULT_VERSION, ERROR_ACTIONS, ERROR_REGISTRY, ParleAccountClient, catalogGitExposureWarning, loadProfile, formatVersionErrorHint, parseKeyValueFile, parseProfiles, performProfileSwitch, profileCatalogHasProfile, redactString, resolveProfileCatalogPath, summarizeSendDelivery, type AcceptRoomInvitationParams, type ClaimPrincipalInviteParams, type ConnectOwnAgentParams, type CredentialProfile, type ErrorAction, type HardenAccountParams, type MintPrincipalInviteParams } from "@parlehq/agent-client";
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
-const PI_EXTENSION_VERSION = "0.1.28";
+const PI_EXTENSION_VERSION = "0.1.29";
 const RUNTIME_SCHEMA_VERSION = 1;
 const AI_GUIDANCE_URL = "https://ai.parle.sh";
 const API_LLMS_URL = "https://api.parle.sh/llms.txt";
@@ -953,6 +953,8 @@ async function requestJson(cfg: ParleConfig, path: string, options: { method?: s
   const headers: Record<string, string> = {
     Accept: "application/json",
     "Parle-Version": cfg.version.value || DEFAULT_VERSION,
+    "Parle-Client-Name": "@parlehq/pi-extension",
+    "Parle-Client-Version": PI_EXTENSION_VERSION,
     Authorization: `Bearer ${cfg.agentToken!.value}`,
   };
   if (options.session && state.sessionHandle) headers["Parle-Agent-Session"] = state.sessionHandle;
@@ -984,10 +986,25 @@ async function requestJson(cfg: ParleConfig, path: string, options: { method?: s
     const json = parseJsonMaybe(text);
     if (!response.ok) {
       const errorObj = json?.error && typeof json.error === "object" ? json.error : {};
+      const code = typeof errorObj.code === "string" ? errorObj.code : undefined;
+      const registry = code ? ERROR_REGISTRY[code] : undefined;
+      const action = typeof errorObj.action === "string" && (ERROR_ACTIONS as readonly string[]).includes(errorObj.action)
+        ? errorObj.action as ErrorAction
+        : registry?.action;
+      const retryAfterHeader = response.headers.get("retry-after");
+      const retryAfterSeconds = retryAfterHeader ? Number(retryAfterHeader) : Number.NaN;
+      const retryAfterMs = typeof errorObj.retry_after_ms === "number" && Number.isFinite(errorObj.retry_after_ms)
+        ? Math.max(0, Math.trunc(errorObj.retry_after_ms))
+        : Number.isFinite(retryAfterSeconds) ? Math.max(0, Math.trunc(retryAfterSeconds * 1000)) : undefined;
       const msg = redactString(errorObj.message || truncateText(redactString(text), 4096).text);
-      const versionHint = response.status === 400 && /version/i.test(`${errorObj.code || ""} ${msg}`) ? formatVersionErrorHint(cfg, errorObj) : "";
+      const versionHint = response.status === 400 && /version/i.test(`${code || ""} ${msg}`) ? formatVersionErrorHint(cfg, errorObj) : "";
       const err: any = new Error(`Parle API ${response.status}: ${msg}${versionHint}`);
       err.status = response.status;
+      err.code = code;
+      err.action = action;
+      err.scope = typeof errorObj.scope === "string" ? errorObj.scope : registry?.scope;
+      err.retryable = typeof errorObj.retryable === "boolean" ? errorObj.retryable : registry?.retryable;
+      err.retryAfterMs = retryAfterMs;
       throw err;
     }
     return json ?? {};
@@ -1273,7 +1290,7 @@ async function withRebootstrap<T>(ctx: any, cfg: ParleConfig, fn: () => Promise<
   try {
     return await fn();
   } catch (error: any) {
-    if (error?.status !== 401 && error?.status !== 404) throw error;
+    if (error?.action !== "rebootstrap") throw error;
     const hadBaseline = Boolean(runtime.baselineAt);
     await bootstrap(ctx, cfg, signal, true);
     if (hadBaseline && !cfg.sessionAlias?.value) await baselineResponsiveDelivery(ctx, cfg, signal);
@@ -1534,6 +1551,18 @@ function recordWatcherError(error: any) {
   runtime.watcherBackoffCount = (runtime.watcherBackoffCount || 0) + 1;
 }
 
+function terminalWatcherState(error: any): WatcherState | undefined {
+  if (error?.action === "reauthorize") return "auth_expired";
+  if (error?.action === "stop" || error?.action === "fix_client") return "disconnected";
+  return undefined;
+}
+
+function watcherRetryDelayMs(error: any): number {
+  return typeof error?.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs)
+    ? Math.max(0, Math.trunc(error.retryAfterMs))
+    : jitteredBackoffMs();
+}
+
 function isPiIdle(ctx: any): boolean {
   return typeof ctx?.isIdle === "function" ? ctx.isIdle() : true;
 }
@@ -1634,15 +1663,17 @@ async function runWatcher(pi: any, ctx: any, cfg: ParleConfig, signal: AbortSign
       } catch (error: any) {
         if (signal.aborted) break;
         recordWatcherError(error);
-        runtime.watcherState = error?.status === 401 ? "auth_expired" : error?.status === 404 ? "session_expired" : "backoff";
+        const terminalState = terminalWatcherState(error);
+        runtime.watcherState = terminalState || (error?.action === "rebootstrap" ? "session_expired" : "backoff");
         setStatus(ctx, cfg);
-        await sleep(jitteredBackoffMs(), signal).catch(() => undefined);
+        if (terminalState) break;
+        await sleep(watcherRetryDelayMs(error), signal).catch(() => undefined);
       }
     }
   } catch (error: any) {
     if (!signal.aborted) {
       recordWatcherError(error);
-      runtime.watcherState = error?.status === 401 ? "auth_expired" : error?.status === 404 ? "session_expired" : "backoff";
+      runtime.watcherState = terminalWatcherState(error) || (error?.action === "rebootstrap" ? "session_expired" : "backoff");
       setStatus(ctx, cfg);
     }
   } finally {
@@ -1650,7 +1681,7 @@ async function runWatcher(pi: any, ctx: any, cfg: ParleConfig, signal: AbortSign
       watcherLoopRunning = false;
       if (signal.aborted) {
         runtime.watcherState = "disconnected";
-      } else if (runtime.watcherState !== "auth_expired" && runtime.watcherState !== "session_expired" && runtime.watcherState !== "backoff") {
+      } else if (runtime.watcherState !== "auth_expired" && runtime.watcherState !== "session_expired" && runtime.watcherState !== "backoff" && runtime.watcherState !== "disconnected") {
         runtime.watcherState = "off";
       }
       setStatus(ctx, cfg);
@@ -1788,6 +1819,8 @@ export const __testing = {
   inboundPrompt,
   summarizeSendDelivery,
   maybeHeartbeatAgentSession,
+  terminalWatcherState,
+  watcherRetryDelayMs,
   startWatcher,
   handleWakeHint,
   queueResponsiveMessages,

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -102,10 +102,11 @@ test("status resolves explicit and default profiles with shared atomic-mode sema
   assert.equal(defaultStatus.details.roomId.source, "profile:default");
 });
 
-test("Pi delegates version error hints to the agent client", () => {
+test("Pi delegates API error taxonomy and version hints to the agent client", () => {
   const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
-  assert.match(source, /formatVersionErrorHint[^\n]*from "@parlehq\/agent-client"/);
+  assert.match(source, /ERROR_ACTIONS, ERROR_REGISTRY[^\n]*formatVersionErrorHint[^\n]*from "@parlehq\/agent-client"/);
   assert.doesNotMatch(source, /function formatVersionErrorHint/);
+  assert.doesNotMatch(source, /const ERROR_REGISTRY/);
 });
 
 test("Pi shares wire defaults with the agent client", () => {
@@ -160,6 +161,63 @@ test("watcher bootstrap failure records status instead of escaping", async () =>
   assert.match(state.lastError, /unsupported Parle-Version/);
 });
 
+function installWatcherFailureHarness(heartbeatResponse) {
+  const cwd = tempProject("PARLE_ROOM_ID=room-1\nPARLE_ROOM_AGENT_TOKEN=token-1\n");
+  let sessionCreates = 0;
+  const heartbeatAt = [];
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith("/v/agent/sessions")) {
+      sessionCreates += 1;
+      return new Response(JSON.stringify({ agent_session_id: "as-watch", session_credential: "parle_ses_watch", expires_at: "2026-07-22T00:00:00Z", address: "@p.a.watch" }), { status: 201 });
+    }
+    if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-watch" }), { status: 201 });
+    if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
+    if (u.includes("/responsive-delivery")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
+    if (u.includes("/heartbeat")) {
+      heartbeatAt.push(Date.now());
+      return heartbeatResponse(heartbeatAt.length);
+    }
+    throw new Error("unexpected " + u);
+  };
+  const harness = installHarness(cwd);
+  return { harness, heartbeatAt, sessionCreates: () => sessionCreates };
+}
+
+test("watcher stops after one terminal invalid-token heartbeat", async () => {
+  const probe = installWatcherFailureHarness(() => new Response(JSON.stringify({ error: { code: "invalid_agent_token", message: "revoked", action: "reauthorize", retryable: false, scope: "agent_token", retry_after_ms: null } }), { status: 401 }));
+
+  await probe.harness.call("parle_status");
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  assert.equal(probe.sessionCreates(), 1);
+  assert.equal(probe.heartbeatAt.length, 1);
+  assert.equal(__testing.runtimeState().watcherState, "auth_expired");
+});
+
+test("watcher honors 429 Retry-After before a terminal 401 stops it", async () => {
+  const probe = installWatcherFailureHarness((attempt) => attempt === 1
+    ? new Response(JSON.stringify({ error: { code: "rate_limited", message: "back off", action: "backoff", retryable: true, scope: "rate_limit", retry_after_ms: 30 } }), { status: 429 })
+    : new Response(JSON.stringify({ error: { code: "invalid_agent_token", message: "revoked", action: "reauthorize", retryable: false, scope: "agent_token", retry_after_ms: null } }), { status: 401 }));
+
+  await probe.harness.call("parle_status");
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  assert.equal(probe.heartbeatAt.length, 2);
+  assert.ok(probe.heartbeatAt[1] - probe.heartbeatAt[0] >= 25);
+  assert.equal(__testing.runtimeState().watcherState, "auth_expired");
+});
+
+test("watcher stops on a terminal stop action", async () => {
+  const probe = installWatcherFailureHarness(() => new Response(JSON.stringify({ error: { code: "participant_revoked", message: "removed", action: "stop", retryable: false, scope: "room_access", retry_after_ms: null } }), { status: 403 }));
+
+  await probe.harness.call("parle_status");
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  assert.equal(probe.heartbeatAt.length, 1);
+  assert.equal(__testing.runtimeState().watcherState, "disconnected");
+});
+
 test("footer shows x when configured Parle cannot bootstrap", async () => {
   const cwd = tempProject("PARLE_ROOM_ID=room-1\nPARLE_ROOM_HANDLE=galexc-intercom\nPARLE_ROOM_AGENT_TOKEN=token-1\nPARLE_VERSION=bad-version\n");
   globalThis.fetch = async () => new Response(JSON.stringify({ error: { code: "unsupported_version", message: "missing or unsupported Parle-Version header" } }), { status: 400 });
@@ -202,7 +260,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.equal(snapshot.roomId, "room-1");
   assert.equal(snapshot.roomHandle, "galexc-intercom");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.1.28" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.1.29" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1200,10 +1258,10 @@ test("advanceCursor false manual reads do not consume responsive delivery", asyn
   assert.equal(__testing.runtimeState().seenSuppressed, undefined);
 });
 
-test("heartbeat 404 reboots the session before the watcher can wedge", async () => {
+test("heartbeat rebootstrap action replaces the session before the watcher can wedge", async () => {
   let sessionCreates = 0;
   let heartbeatCalls = 0;
-  const harness = installSendHarness(async (url) => {
+  const harness = installSendHarness(async (url, init = {}) => {
     const u = String(url);
     if (u.endsWith("/v/agent/sessions")) {
       sessionCreates += 1;
@@ -1213,7 +1271,9 @@ test("heartbeat 404 reboots the session before the watcher can wedge", async () 
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
     if (u.includes("/heartbeat")) {
       heartbeatCalls += 1;
-      if (heartbeatCalls === 1) return new Response(JSON.stringify({ error: { message: "not found" } }), { status: 404 });
+      assert.equal(init.headers["Parle-Client-Name"], "@parlehq/pi-extension");
+      assert.equal(init.headers["Parle-Client-Version"], "0.1.29");
+      if (heartbeatCalls === 1) return new Response(JSON.stringify({ error: { code: "agent_session_ended", message: "ended", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }), { status: 401 });
       return new Response(null, { status: 204 });
     }
     throw new Error("unexpected " + u);
@@ -1229,7 +1289,42 @@ test("heartbeat 404 reboots the session before the watcher can wedge", async () 
   assert.equal(typeof __testing.runtimeState().lastHeartbeatAt, "string");
 });
 
-test("room tool calls rebootstrap after session 404", async () => {
+test("terminal invalid agent token does not rebootstrap or enter a heartbeat loop", async () => {
+  let sessionCreates = 0;
+  let heartbeatCalls = 0;
+  const harness = installSendHarness(async (url) => {
+    const u = String(url);
+    if (u.endsWith("/v/agent/sessions")) {
+      sessionCreates += 1;
+      return new Response(JSON.stringify({ agent_session_id: "as-terminal", session_credential: "parle_ses_terminal", expires_at: "2026-07-04T00:00:00Z", address: "@p.a.terminal" }), { status: 201 });
+    }
+    if (u.endsWith("/participants")) return new Response(JSON.stringify({ participant_id: "p-terminal" }), { status: 201 });
+    if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
+    if (u.includes("/heartbeat")) {
+      heartbeatCalls += 1;
+      return new Response(JSON.stringify({ error: { code: "invalid_agent_token", message: "revoked", action: "reauthorize", retryable: false, scope: "agent_token", retry_after_ms: null } }), { status: 401 });
+    }
+    throw new Error("unexpected " + u);
+  });
+
+  await harness.call("parle_status");
+  const cfg = __testing.resolveConfig(harness.cwd);
+  await assert.rejects(__testing.maybeHeartbeatAgentSession(harness.ctx, cfg), (error) => {
+    assert.equal(error.status, 401);
+    assert.equal(error.code, "invalid_agent_token");
+    assert.equal(error.action, "reauthorize");
+    assert.equal(error.retryable, false);
+    return true;
+  });
+
+  assert.equal(sessionCreates, 1);
+  assert.equal(heartbeatCalls, 1);
+  assert.equal(__testing.terminalWatcherState({ action: "reauthorize" }), "auth_expired");
+  assert.equal(__testing.terminalWatcherState({ action: "fix_client" }), "disconnected");
+  assert.equal(__testing.watcherRetryDelayMs({ retryAfterMs: 120_000 }), 120_000);
+});
+
+test("room tool calls rebootstrap on the server action", async () => {
   let sessionCreates = 0;
   let inboxCalls = 0;
   const harness = installSendHarness(async (url) => {
@@ -1242,7 +1337,7 @@ test("room tool calls rebootstrap after session 404", async () => {
     if (u.includes("/projection")) return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
     if (u.includes("/inbound")) {
       inboxCalls += 1;
-      if (inboxCalls === 1) return new Response(JSON.stringify({ error: { message: "not found" } }), { status: 404 });
+      if (inboxCalls === 1) return new Response(JSON.stringify({ error: { code: "agent_session_expired", message: "expired", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }), { status: 401 });
       return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
     }
     throw new Error("unexpected " + u);
@@ -1273,7 +1368,7 @@ test("mid-run unpinned rebootstrap baselines the new session before retry", asyn
     }
     if (u.includes("/inbound")) {
       inboxCalls += 1;
-      if (inboxCalls === 1) return new Response(JSON.stringify({ error: { message: "not found" } }), { status: 404 });
+      if (inboxCalls === 1) return new Response(JSON.stringify({ error: { code: "agent_session_expired", message: "expired", action: "rebootstrap", retryable: false, scope: "agent_session", retry_after_ms: null } }), { status: 401 });
       return new Response(JSON.stringify({ watermark: 0, messages: [] }), { status: 200 });
     }
     throw new Error("unexpected " + u);


### PR DESCRIPTION
## Summary
- preserve structured Parle API error metadata in the Pi adapter
- stop heartbeat retry loops for terminal reauthorize, stop, and fix-client actions
- honor server retry delays and add client attribution headers
- release the Pi extension as 0.1.29

## Validation
- `pnpm -F @parlehq/pi-extension typecheck`
- `pnpm -F @parlehq/pi-extension test` (61 passing)