### PR TITLE
Build Claude Desktop MCPB from a clean checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "packageManager": "pnpm@11.18.0",
   "scripts": {
     "build": "pnpm -r build",
+    "build:mcp": "pnpm --filter @parlehq/mcp-server... build",
+    "pack:desktop": "pnpm build:mcp && pnpm -F @parlehq/claude-desktop-extension pack:mcpb",
     "check:manifests": "node scripts/check-manifest-versions.mjs",
     "sync-conformance": "node scripts/sync-conformance.mjs",
     "typecheck": "pnpm -r typecheck",

--- a/packages/claude-desktop-extension/README.md
+++ b/packages/claude-desktop-extension/README.md
@@ -18,17 +18,24 @@ Desktop setup is env-only in v1. Project `.env` discovery is not documented as a
 
 `parle_harden_account` accepts no password, OTP, recovery code, cookie, URI, or arbitrary path and never launches the human helper. The account owner must run `parle-hardening-secret` independently in a separate controlling terminal. Disable terminal scrollback and recording before displaying a provisioning QR. Follow the [operator ceremony](../../docs/account-hardening-ceremony.md).
 
-## Validation
+## Build and validation
 
-Run from the repo root:
+From a clean checkout, build the shared client and MCP server in dependency order, then emit the installable MCPB:
 
 ```bash
-pnpm -F @parlehq/mcp-server build
-pnpm -F @parlehq/claude-desktop-extension build
+pnpm install
+pnpm pack:desktop
+```
+
+The bundle is written to `packages/claude-desktop-extension/out/parle-claude-desktop-extension.mcpb`.
+
+Run the full package validation after building:
+
+```bash
 pnpm -F @parlehq/claude-desktop-extension test
 ```
 
-The test path validates the manifest with `@anthropic-ai/mcpb@2.1.2`, packs from a clean staging directory, unpacks the bundle, inspects the archive contents, and runs package-local secret scans.
+`pack:desktop` uses pnpm's dependency-aware filter to build `@parlehq/agent-client` before `@parlehq/mcp-server`; it does not rely on an ignored `packages/client/dist` tree from an earlier build. The package-local `pack:mcpb` script stages, validates, and packs the bundle. The test path additionally runs the MCP smoke test, unpacks and inspects the archive, and runs package-local secret scans.
 
 ## Local Desktop validation checklist
 

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/copy-mcp-artifact.mjs && node scripts/stage-mcpb.mjs && pnpm dlx @anthropic-ai/mcpb@2.1.2 validate manifest.json",
+    "pack:mcpb": "pnpm build && pnpm dlx @anthropic-ai/mcpb@2.1.2 pack out/staging out/parle-claude-desktop-extension.mcpb",
     "typecheck": "echo 'No TypeScript sources' && node scripts/check-mcp-artifact.mjs",
-    "test": "node scripts/check-mcp-artifact.mjs && node scripts/smoke-server.mjs && node scripts/stage-mcpb.mjs && pnpm dlx @anthropic-ai/mcpb@2.1.2 validate manifest.json && pnpm dlx @anthropic-ai/mcpb@2.1.2 pack out/staging out/parle-claude-desktop-extension.mcpb && rm -rf out/unpacked && pnpm dlx @anthropic-ai/mcpb@2.1.2 unpack out/parle-claude-desktop-extension.mcpb out/unpacked && node scripts/inspect-pack.mjs out/unpacked && node scripts/secret-scan.mjs . out/staging out/unpacked"
+    "test": "node scripts/check-mcp-artifact.mjs && node scripts/smoke-server.mjs && pnpm run pack:mcpb && rm -rf out/unpacked && pnpm dlx @anthropic-ai/mcpb@2.1.2 unpack out/parle-claude-desktop-extension.mcpb out/unpacked && node scripts/inspect-pack.mjs out/unpacked && node scripts/secret-scan.mjs . out/staging out/unpacked"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

- add a dependency-aware root build path for the shared client and MCP server
- add an explicit MCPB pack script and clean-checkout root command
- document the emitted bundle path and full validation command

## Validation

- removed ignored client and MCP build output before running `pnpm pack:desktop`
- `pnpm check:manifests`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`

## Tracker

This addresses the clean-clone build-order and hidden pack-target findings. Issue #54 remains open for isolated artifact reproducibility enforcement in CI.