### PR TITLE
Upload Claude Desktop MCPB from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,11 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Upload Claude Desktop MCPB
+        uses: actions/upload-artifact@v4
+        with:
+          name: parle-claude-desktop-extension
+          path: packages/claude-desktop-extension/out/parle-claude-desktop-extension.mcpb
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Summary

Upload the validated Claude Desktop MCPB as a GitHub Actions artifact after the full test and secret-scan path succeeds.

The artifact is named `parle-claude-desktop-extension`, missing output fails the job, and retention is 14 days.

## Validation

- workflow diff passes `git diff --check`
- confirmed `pnpm test` leaves the expected MCPB at the uploaded path