### PR TITLE
Use current artifact upload action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: pnpm test
 
       - name: Upload Claude Desktop MCPB
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: parle-claude-desktop-extension
           path: packages/claude-desktop-extension/out/parle-claude-desktop-extension.mcpb


### PR DESCRIPTION
Update `actions/upload-artifact` to v7 so the MCPB upload uses the current Node 24 action runtime without the v4 deprecation annotation.

The prior main run successfully uploaded the MCPB; this is the compatibility follow-up.