### PR TITLE
Enforce reproducible MCP wrapper artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Check manifest versions
         run: pnpm check:manifests
 
+      - name: Check clean MCP artifact reproducibility
+        run: pnpm check:mcp-artifacts
+
       - name: Build
         run: pnpm build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,12 @@ This repository is the public home for Parle agent harness adapters.
 - `packages/client` - shared Parle agent client primitives (`@parlehq/agent-client`).
 - `packages/mcp-server` - host-agnostic stdio MCP server package, bundled to a single artifact.
 - `packages/pi-extension` - Pi adapter package.
-- `packages/claude-plugin` - Claude Code plugin directory wrapping the bundled MCP server artifact. The tracked `dist/parle-mcp.js` is copied from the mcp-server build; rebuild with `pnpm -F @parlehq/mcp-server build && pnpm -F @parlehq/claude-plugin build` after server changes.
-- `packages/command-code` - Command Code Agent Skill wrapping the bundled MCP server artifact and responsive-delivery hook. The tracked `skills/parle/server/parle-mcp.js` is copied from the mcp-server build; rebuild with `pnpm -F @parlehq/mcp-server build && pnpm -F @parlehq/command-code-adapter build` after server changes.
-- `packages/codex-plugin` - Codex plugin wrapping the bundled MCP server artifact and focused Agent Skill guidance. The tracked `dist/parle-mcp.js` is copied from the mcp-server build; rebuild with `pnpm -F @parlehq/mcp-server build && pnpm -F @parlehq/codex-plugin build` after server changes.
-- `packages/claude-desktop-extension` - Claude Desktop MCPB package wrapping the same bundled MCP server artifact. The tracked `server/parle-mcp.js` is copied from the mcp-server build; rebuild with `pnpm -F @parlehq/mcp-server build && pnpm -F @parlehq/claude-desktop-extension build` after server changes.
+- `packages/claude-plugin` - Claude Code plugin directory wrapping the bundled MCP server artifact.
+- `packages/command-code` - Command Code Agent Skill wrapping the bundled MCP server artifact and responsive-delivery hook.
+- `packages/codex-plugin` - Codex plugin wrapping the bundled MCP server artifact and focused Agent Skill guidance.
+- `packages/claude-desktop-extension` - Claude Desktop MCPB package wrapping the same bundled MCP server artifact.
+
+After shared client or MCP server changes, run `pnpm refresh:mcp-artifacts` to rebuild canonical source in dependency order and refresh all four tracked MCP wrappers. Run `pnpm check:mcp-artifacts` before committing to verify clean-checkout reproducibility and stale-dist isolation. Apply the package version and changelog policy below to every wrapper whose bundled runtime changed.
 
 ## Tooling
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,13 @@ This loads only the Pi extension exposed by this repo's Pi package manifest. The
 
 ```bash
 pnpm install
+pnpm check:mcp-artifacts
 pnpm test
 pnpm typecheck
 pnpm build
 ```
+
+After shared client or MCP server changes, run `pnpm refresh:mcp-artifacts` before the reproducibility check. Commit all four refreshed wrapper artifacts and apply the package version and changelog policy in `AGENTS.md`.
 
 ## License
 

--- a/docs/design/adapter-maintenance-strategy.md
+++ b/docs/design/adapter-maintenance-strategy.md
@@ -106,17 +106,16 @@ Desktop update not required:
 - direct HTTP docs changes only
 - internal client refactors hidden behind the MCP server bundle
 
-Artifact refresh command:
+Canonical artifact refresh and reproducibility commands:
 
 ```bash
-pnpm -F @parlehq/mcp-server build
-pnpm -F @parlehq/claude-plugin build
-pnpm -F @parlehq/claude-desktop-extension build
-pnpm -F @parlehq/claude-plugin test
-pnpm -F @parlehq/claude-desktop-extension test
+pnpm refresh:mcp-artifacts
+pnpm check:mcp-artifacts
 ```
 
-When #6/#7 lands, do one combined artifact refresh for both Claude wrappers.
+The refresh builds `@parlehq/agent-client` before `@parlehq/mcp-server`, then copies the canonical MCP output into the tracked Claude Code, Claude Desktop, Command Code, and Codex wrappers. The check runs before the ordinary repo build in CI. It creates an isolated tracked-source tree with no ignored build output, seeds a stale client dist fixture, rebuilds through the canonical dependency-aware path, and byte-compares all four tracked wrappers. It also proves that a modified wrapper is rejected.
+
+A bundled runtime change requires a version and changelog decision for every affected wrapper. Follow `AGENTS.md`: bump each wrapper version when installable behavior or packaged runtime semantics changed, and document any intentional no-bump case in the commit or release change.
 
 ## Skills versus Desktop extension
 
@@ -181,9 +180,9 @@ pnpm test
 
 Additional artifact checks:
 
-- rebuild MCP server
-- verify `packages/claude-plugin/dist/parle-mcp.js` is byte-identical
-- verify `packages/claude-desktop-extension/server/parle-mcp.js` is byte-identical
+- run `pnpm check:mcp-artifacts` before the ordinary build can overwrite tracked wrappers
+- verify the Claude Code, Claude Desktop, Command Code, and Codex MCP artifacts are byte-identical to a clean canonical build
+- prove stale ignored client output cannot influence the MCP bundle
 - pack Desktop MCPB from staging
 - unpack and inspect allowlisted contents
 - secret scan staged and unpacked artifacts

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build": "pnpm -r build",
     "build:mcp": "pnpm --filter @parlehq/mcp-server... build",
+    "refresh:mcp-artifacts": "pnpm build:mcp && pnpm -F @parlehq/claude-plugin build && pnpm -F @parlehq/claude-desktop-extension build && pnpm -F @parlehq/command-code-adapter build && pnpm -F @parlehq/codex-plugin build",
+    "check:mcp-artifacts": "node scripts/check-reproducible-mcp-artifacts.mjs",
     "pack:desktop": "pnpm build:mcp && pnpm -F @parlehq/claude-desktop-extension pack:mcpb",
     "check:manifests": "node scripts/check-manifest-versions.mjs",
     "sync-conformance": "node scripts/sync-conformance.mjs",

--- a/scripts/check-reproducible-mcp-artifacts.mjs
+++ b/scripts/check-reproducible-mcp-artifacts.mjs
@@ -1,0 +1,107 @@
+import {
+  appendFileSync,
+  chmodSync,
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const canonicalArtifact = "packages/mcp-server/dist/parle-mcp.js";
+const wrapperArtifacts = [
+  "packages/claude-plugin/dist/parle-mcp.js",
+  "packages/claude-desktop-extension/server/parle-mcp.js",
+  "packages/command-code/skills/parle/server/parle-mcp.js",
+  "packages/codex-plugin/dist/parle-mcp.js",
+];
+const staleSentinel = "stale-ignored-client-dist-fixture";
+
+function run(command, args, cwd) {
+  execFileSync(command, args, { cwd, stdio: "inherit", env: process.env });
+}
+
+function copyWorkingTree(targetRoot) {
+  const listed = execFileSync(
+    "git",
+    ["ls-files", "-z", "--cached"],
+    { cwd: repoRoot, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+
+  for (const relativePath of listed.split("\0").filter(Boolean)) {
+    const source = resolve(repoRoot, relativePath);
+    const target = resolve(targetRoot, relativePath);
+    const stat = lstatSync(source);
+    mkdirSync(dirname(target), { recursive: true });
+    if (stat.isSymbolicLink()) {
+      symlinkSync(readlinkSync(source), target);
+    } else if (stat.isFile()) {
+      copyFileSync(source, target);
+      chmodSync(target, stat.mode);
+    }
+  }
+}
+
+function assertArtifactsMatch(root) {
+  const canonicalBytes = readFileSync(resolve(root, canonicalArtifact));
+  for (const relativePath of wrapperArtifacts) {
+    const wrapperBytes = readFileSync(resolve(root, relativePath));
+    if (!canonicalBytes.equals(wrapperBytes)) {
+      throw new Error(`${relativePath} differs from the clean canonical MCP build. Run pnpm refresh:mcp-artifacts and commit the required wrapper version and changelog updates.`);
+    }
+  }
+}
+
+function seedStaleClientDist(root) {
+  run("pnpm", ["-F", "@parlehq/agent-client", "build"], root);
+  const fixturePath = resolve(root, "packages/client/dist/conformance-data.js");
+  const compiled = readFileSync(fixturePath, "utf8");
+  const changed = compiled.replace(
+    /CONFORMANCE_PARLE_VERSION\s*=\s*"[^"]+"/,
+    `CONFORMANCE_PARLE_VERSION = "${staleSentinel}"`,
+  );
+  if (changed === compiled) throw new Error("Could not seed the stale client dist fixture because the compiled conformance version shape changed.");
+  writeFileSync(fixturePath, changed);
+}
+
+function assertStaleFixtureWasRebuilt(root) {
+  const canonicalBytes = readFileSync(resolve(root, canonicalArtifact), "utf8");
+  if (canonicalBytes.includes(staleSentinel)) {
+    throw new Error("The canonical MCP build consumed stale ignored client dist output instead of rebuilding @parlehq/agent-client first.");
+  }
+}
+
+function assertDivergenceDetection(root) {
+  const probeTarget = wrapperArtifacts[0];
+  appendFileSync(resolve(root, probeTarget), "\n// reproducibility-gate-divergence-probe\n");
+  try {
+    assertArtifactsMatch(root);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(probeTarget)) return;
+    throw error;
+  }
+  throw new Error("The reproducibility gate did not reject a modified tracked wrapper artifact.");
+}
+
+const isolatedRoot = mkdtempSync(join(tmpdir(), "parle-adapters-artifact-check-"));
+try {
+  copyWorkingTree(isolatedRoot);
+  run("pnpm", ["install", "--filter", "@parlehq/mcp-server...", "--frozen-lockfile", "--offline"], isolatedRoot);
+  seedStaleClientDist(isolatedRoot);
+  run("pnpm", ["build:mcp"], isolatedRoot);
+  assertStaleFixtureWasRebuilt(isolatedRoot);
+  assertArtifactsMatch(isolatedRoot);
+  assertDivergenceDetection(isolatedRoot);
+  console.log("Clean MCP artifact reproducibility, stale-dist isolation, and wrapper divergence checks passed.");
+} finally {
+  rmSync(isolatedRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- add an isolated clean-source MCP reproducibility gate
- seed stale ignored client output and prove the canonical dependency-aware build replaces it
- byte-compare the clean MCP bundle against Claude Code, Claude Desktop, Command Code, and Codex tracked wrappers
- prove the gate rejects a modified wrapper
- run the gate before the ordinary CI build can overwrite tracked artifacts
- document one refresh command and wrapper version and changelog expectations

Closes #54.

## Validation

- `pnpm check:mcp-artifacts`
- `pnpm refresh:mcp-artifacts` with no wrapper diff
- `pnpm check:manifests`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- independent build reproducibility review found no blockers