### PR TITLE
Recover responsive delivery after missed wakes

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.8 (2026-08-06)
+
+- Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).
+
 ## 0.8.7 (2026-08-06)
 
 - Refresh the bundled MCP runtime with the `parle_reply` opaque-route tool and conservative reply failure semantics (#74).

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.7"
+        "PARLE_INTEGRATION_VERSION": "0.8.8"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -33990,7 +33990,10 @@ function compactStatusCardFromStatus(status) {
 var DEFAULT_MAX_HANDLER_ATTEMPTS = 3;
 var DEFAULT_MAX_DRAIN_BATCHES = 100;
 var DEFAULT_RECONNECT_MS = 5e3;
-var EMPTY_STREAM_REOPEN_MS = 250;
+var DEFAULT_FALLBACK_MS = 12e4;
+var DEFAULT_FALLBACK_JITTER_MS = 3e4;
+var DEFAULT_RECONNECT_JITTER_MS = 3e4;
+var MAX_TIMER_MS = 2147483647;
 var MAX_REMEMBERED_KEYS = 5e3;
 function deliveryKey(roomId, message) {
   return `${roomId}:${message.event_id}`;
@@ -34014,6 +34017,7 @@ var ResponsiveDeliveryController = class {
   maxDrainBatches;
   reconnectDelayMs;
   sleep;
+  random;
   onWakeError;
   onWakeOpen;
   // Deduplication is keyed by (roomId, eventId) and deliberately survives
@@ -34038,6 +34042,11 @@ var ResponsiveDeliveryController = class {
   ignoredWakeHints = 0;
   lastIgnoredWakeRoomId;
   lastError;
+  wakeTiming = {
+    fallbackMs: DEFAULT_FALLBACK_MS,
+    fallbackJitterMs: DEFAULT_FALLBACK_JITTER_MS,
+    reconnectJitterMs: DEFAULT_RECONNECT_JITTER_MS
+  };
   constructor(client, options) {
     this.client = client;
     this.handler = options.handler;
@@ -34045,6 +34054,7 @@ var ResponsiveDeliveryController = class {
     this.maxDrainBatches = options.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES;
     this.reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_RECONNECT_MS;
     this.sleep = options.sleep ?? defaultSleep;
+    this.random = options.random ?? Math.random;
     this.onWakeError = options.onWakeError;
     this.onWakeOpen = options.onWakeOpen;
   }
@@ -34076,7 +34086,6 @@ var ResponsiveDeliveryController = class {
     this.unsubscribeRevision?.();
     this.unsubscribeRevision = this.client.onSessionRevision?.(() => {
       this.wakeAbort?.abort();
-      void this.drainAll().catch(() => void 0);
     });
     await this.drainAll();
     const loop = this.watchLoop();
@@ -34135,59 +34144,106 @@ var ResponsiveDeliveryController = class {
     return this.configuredRooms().filter((room) => room.state === "ready");
   }
   async watchLoop() {
-    while (!this.abort.signal.aborted) {
-      const wakeAbort = new AbortController();
-      this.wakeAbort = wakeAbort;
-      const onAbort = () => wakeAbort.abort();
-      this.abort.signal.addEventListener("abort", onAbort, { once: true });
-      try {
-        const response = await this.client.openWakeStream(wakeAbort.signal);
-        const reader = response.body?.getReader();
-        if (!reader)
-          throw new Error("Parle wake stream has no body");
-        this.lastError = void 0;
-        this.onWakeOpen?.();
-        const cancelRead = () => void reader.cancel().catch(() => void 0);
-        wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let sawEvent = false;
-        while (!wakeAbort.signal.aborted) {
-          const { value, done } = await reader.read();
-          if (done)
-            break;
-          buffer += decoder.decode(value, { stream: true });
-          const parsed = parseSSEBlocks(buffer);
-          buffer = parsed.rest;
-          for (const event of parsed.events) {
-            sawEvent = true;
-            if (event.event === "wake")
-              await this.handleWake(event.data);
-          }
-        }
-        this.lastError = void 0;
-        if (!wakeAbort.signal.aborted && !sawEvent)
-          await this.sleep(EMPTY_STREAM_REOPEN_MS, this.abort.signal);
-      } catch (error51) {
-        if (this.abort.signal.aborted)
-          break;
-        if (wakeAbort.signal.aborted)
-          continue;
-        this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
-        if (this.onWakeError?.(error51) === "stop")
-          return;
-        if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
-          throw error51;
-        const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+    const fallbackAbort = new AbortController();
+    const abortFallback = () => fallbackAbort.abort();
+    this.abort.signal.addEventListener("abort", abortFallback, { once: true });
+    const fallback = this.fallbackLoop(fallbackAbort.signal);
+    try {
+      while (!this.abort.signal.aborted) {
+        const wakeAbort = new AbortController();
+        this.wakeAbort = wakeAbort;
+        const onAbort = () => wakeAbort.abort();
+        this.abort.signal.addEventListener("abort", onAbort, { once: true });
         try {
-          await this.sleep(Math.max(retryAfter, this.reconnectDelayMs), this.abort.signal);
-        } catch {
-          break;
+          const response = await this.client.openWakeStream(wakeAbort.signal);
+          const reader = response.body?.getReader();
+          if (!reader)
+            throw new Error("Parle wake stream has no body");
+          const cancelRead = () => void reader.cancel().catch(() => void 0);
+          wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
+          await this.drainAll();
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = void 0;
+          this.onWakeOpen?.();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (!wakeAbort.signal.aborted) {
+            const { value, done } = await reader.read();
+            if (done)
+              break;
+            buffer += decoder.decode(value, { stream: true });
+            const parsed = parseSSEBlocks(buffer);
+            buffer = parsed.rest;
+            for (const event of parsed.events) {
+              if (event.event === "config")
+                this.applyWakeConfig(event.data);
+              else if (event.event === "wake")
+                await this.handleWake(event.data);
+            }
+          }
+          if (!wakeAbort.signal.aborted)
+            throw new Error("Parle wake stream ended unexpectedly");
+        } catch (error51) {
+          if (this.abort.signal.aborted)
+            break;
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
+          if (this.onWakeError?.(error51) === "stop")
+            return;
+          if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
+            throw error51;
+          const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+          try {
+            await this.sleep(this.withJitter(Math.max(retryAfter, this.reconnectDelayMs), this.wakeTiming.reconnectJitterMs), this.abort.signal);
+          } catch {
+            break;
+          }
+        } finally {
+          this.abort.signal.removeEventListener("abort", onAbort);
         }
-      } finally {
-        this.abort.signal.removeEventListener("abort", onAbort);
       }
+    } finally {
+      fallbackAbort.abort();
+      await fallback;
+      this.abort.signal.removeEventListener("abort", abortFallback);
     }
+  }
+  async fallbackLoop(signal) {
+    while (!signal.aborted) {
+      const timing = this.wakeTiming;
+      try {
+        await this.sleep(this.withJitter(timing.fallbackMs, timing.fallbackJitterMs), signal);
+      } catch {
+        return;
+      }
+      if (signal.aborted)
+        return;
+      await this.drainAll();
+    }
+  }
+  applyWakeConfig(data) {
+    let config2;
+    try {
+      config2 = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (!config2 || typeof config2 !== "object")
+      return;
+    const positive = (value) => Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= MAX_TIMER_MS;
+    const nonNegative = (value) => Number.isSafeInteger(value) && Number(value) >= 0 && Number(value) <= MAX_TIMER_MS;
+    this.wakeTiming = {
+      fallbackMs: positive(config2.fallback_ms) ? config2.fallback_ms : this.wakeTiming.fallbackMs,
+      fallbackJitterMs: nonNegative(config2.fallback_jitter_ms) ? config2.fallback_jitter_ms : this.wakeTiming.fallbackJitterMs,
+      reconnectJitterMs: nonNegative(config2.reconnect_jitter_ms) ? config2.reconnect_jitter_ms : this.wakeTiming.reconnectJitterMs
+    };
+  }
+  withJitter(baseMs, jitterMs) {
+    const random = this.random();
+    const sample = Number.isFinite(random) ? Math.min(Math.max(random, 0), 1 - Number.EPSILON) : 0;
+    return Math.min(baseMs + Math.floor(sample * (Math.max(jitterMs, 0) + 1)), MAX_TIMER_MS);
   }
   // A hint names the room with traffic. An unknown room is counted and ignored;
   // a hintless wake falls back to draining every ready room.
@@ -34228,9 +34284,9 @@ var ResponsiveDeliveryController = class {
     await this.drainRoom(current);
   }
   // Coalescing must not swallow a requested drain. Joining an in-flight drain
-  // would lose the immediate post-replacement pass a session revision promises,
-  // because the in-flight drain may already have read past the new rows. One
-  // rerun is queued per room instead.
+  // would lose a wake, reconnect, revision, or fallback pass because the
+  // in-flight drain may already have read past the new rows. One rerun is queued
+  // per room instead.
   drainRoom(room) {
     const existing = this.drainInFlight.get(room.roomId);
     if (existing) {
@@ -36829,7 +36885,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.7";
+var MCP_CLIENT_VERSION = "0.7.8";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
       ],
       "env": {
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.7"
+        "PARLE_INTEGRATION_VERSION": "0.9.8"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.8 (2026-08-06)
+
+- Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).
+
 ## 0.9.7 (2026-08-06)
 
 - Refresh the bundled MCP runtime and responsive hook for opaque route replies and bounded-interaction warnings (#74).

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -33990,7 +33990,10 @@ function compactStatusCardFromStatus(status) {
 var DEFAULT_MAX_HANDLER_ATTEMPTS = 3;
 var DEFAULT_MAX_DRAIN_BATCHES = 100;
 var DEFAULT_RECONNECT_MS = 5e3;
-var EMPTY_STREAM_REOPEN_MS = 250;
+var DEFAULT_FALLBACK_MS = 12e4;
+var DEFAULT_FALLBACK_JITTER_MS = 3e4;
+var DEFAULT_RECONNECT_JITTER_MS = 3e4;
+var MAX_TIMER_MS = 2147483647;
 var MAX_REMEMBERED_KEYS = 5e3;
 function deliveryKey(roomId, message) {
   return `${roomId}:${message.event_id}`;
@@ -34014,6 +34017,7 @@ var ResponsiveDeliveryController = class {
   maxDrainBatches;
   reconnectDelayMs;
   sleep;
+  random;
   onWakeError;
   onWakeOpen;
   // Deduplication is keyed by (roomId, eventId) and deliberately survives
@@ -34038,6 +34042,11 @@ var ResponsiveDeliveryController = class {
   ignoredWakeHints = 0;
   lastIgnoredWakeRoomId;
   lastError;
+  wakeTiming = {
+    fallbackMs: DEFAULT_FALLBACK_MS,
+    fallbackJitterMs: DEFAULT_FALLBACK_JITTER_MS,
+    reconnectJitterMs: DEFAULT_RECONNECT_JITTER_MS
+  };
   constructor(client, options) {
     this.client = client;
     this.handler = options.handler;
@@ -34045,6 +34054,7 @@ var ResponsiveDeliveryController = class {
     this.maxDrainBatches = options.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES;
     this.reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_RECONNECT_MS;
     this.sleep = options.sleep ?? defaultSleep;
+    this.random = options.random ?? Math.random;
     this.onWakeError = options.onWakeError;
     this.onWakeOpen = options.onWakeOpen;
   }
@@ -34076,7 +34086,6 @@ var ResponsiveDeliveryController = class {
     this.unsubscribeRevision?.();
     this.unsubscribeRevision = this.client.onSessionRevision?.(() => {
       this.wakeAbort?.abort();
-      void this.drainAll().catch(() => void 0);
     });
     await this.drainAll();
     const loop = this.watchLoop();
@@ -34135,59 +34144,106 @@ var ResponsiveDeliveryController = class {
     return this.configuredRooms().filter((room) => room.state === "ready");
   }
   async watchLoop() {
-    while (!this.abort.signal.aborted) {
-      const wakeAbort = new AbortController();
-      this.wakeAbort = wakeAbort;
-      const onAbort = () => wakeAbort.abort();
-      this.abort.signal.addEventListener("abort", onAbort, { once: true });
-      try {
-        const response = await this.client.openWakeStream(wakeAbort.signal);
-        const reader = response.body?.getReader();
-        if (!reader)
-          throw new Error("Parle wake stream has no body");
-        this.lastError = void 0;
-        this.onWakeOpen?.();
-        const cancelRead = () => void reader.cancel().catch(() => void 0);
-        wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let sawEvent = false;
-        while (!wakeAbort.signal.aborted) {
-          const { value, done } = await reader.read();
-          if (done)
-            break;
-          buffer += decoder.decode(value, { stream: true });
-          const parsed = parseSSEBlocks(buffer);
-          buffer = parsed.rest;
-          for (const event of parsed.events) {
-            sawEvent = true;
-            if (event.event === "wake")
-              await this.handleWake(event.data);
-          }
-        }
-        this.lastError = void 0;
-        if (!wakeAbort.signal.aborted && !sawEvent)
-          await this.sleep(EMPTY_STREAM_REOPEN_MS, this.abort.signal);
-      } catch (error51) {
-        if (this.abort.signal.aborted)
-          break;
-        if (wakeAbort.signal.aborted)
-          continue;
-        this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
-        if (this.onWakeError?.(error51) === "stop")
-          return;
-        if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
-          throw error51;
-        const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+    const fallbackAbort = new AbortController();
+    const abortFallback = () => fallbackAbort.abort();
+    this.abort.signal.addEventListener("abort", abortFallback, { once: true });
+    const fallback = this.fallbackLoop(fallbackAbort.signal);
+    try {
+      while (!this.abort.signal.aborted) {
+        const wakeAbort = new AbortController();
+        this.wakeAbort = wakeAbort;
+        const onAbort = () => wakeAbort.abort();
+        this.abort.signal.addEventListener("abort", onAbort, { once: true });
         try {
-          await this.sleep(Math.max(retryAfter, this.reconnectDelayMs), this.abort.signal);
-        } catch {
-          break;
+          const response = await this.client.openWakeStream(wakeAbort.signal);
+          const reader = response.body?.getReader();
+          if (!reader)
+            throw new Error("Parle wake stream has no body");
+          const cancelRead = () => void reader.cancel().catch(() => void 0);
+          wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
+          await this.drainAll();
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = void 0;
+          this.onWakeOpen?.();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (!wakeAbort.signal.aborted) {
+            const { value, done } = await reader.read();
+            if (done)
+              break;
+            buffer += decoder.decode(value, { stream: true });
+            const parsed = parseSSEBlocks(buffer);
+            buffer = parsed.rest;
+            for (const event of parsed.events) {
+              if (event.event === "config")
+                this.applyWakeConfig(event.data);
+              else if (event.event === "wake")
+                await this.handleWake(event.data);
+            }
+          }
+          if (!wakeAbort.signal.aborted)
+            throw new Error("Parle wake stream ended unexpectedly");
+        } catch (error51) {
+          if (this.abort.signal.aborted)
+            break;
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
+          if (this.onWakeError?.(error51) === "stop")
+            return;
+          if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
+            throw error51;
+          const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+          try {
+            await this.sleep(this.withJitter(Math.max(retryAfter, this.reconnectDelayMs), this.wakeTiming.reconnectJitterMs), this.abort.signal);
+          } catch {
+            break;
+          }
+        } finally {
+          this.abort.signal.removeEventListener("abort", onAbort);
         }
-      } finally {
-        this.abort.signal.removeEventListener("abort", onAbort);
       }
+    } finally {
+      fallbackAbort.abort();
+      await fallback;
+      this.abort.signal.removeEventListener("abort", abortFallback);
     }
+  }
+  async fallbackLoop(signal) {
+    while (!signal.aborted) {
+      const timing = this.wakeTiming;
+      try {
+        await this.sleep(this.withJitter(timing.fallbackMs, timing.fallbackJitterMs), signal);
+      } catch {
+        return;
+      }
+      if (signal.aborted)
+        return;
+      await this.drainAll();
+    }
+  }
+  applyWakeConfig(data) {
+    let config2;
+    try {
+      config2 = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (!config2 || typeof config2 !== "object")
+      return;
+    const positive = (value) => Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= MAX_TIMER_MS;
+    const nonNegative = (value) => Number.isSafeInteger(value) && Number(value) >= 0 && Number(value) <= MAX_TIMER_MS;
+    this.wakeTiming = {
+      fallbackMs: positive(config2.fallback_ms) ? config2.fallback_ms : this.wakeTiming.fallbackMs,
+      fallbackJitterMs: nonNegative(config2.fallback_jitter_ms) ? config2.fallback_jitter_ms : this.wakeTiming.fallbackJitterMs,
+      reconnectJitterMs: nonNegative(config2.reconnect_jitter_ms) ? config2.reconnect_jitter_ms : this.wakeTiming.reconnectJitterMs
+    };
+  }
+  withJitter(baseMs, jitterMs) {
+    const random = this.random();
+    const sample = Number.isFinite(random) ? Math.min(Math.max(random, 0), 1 - Number.EPSILON) : 0;
+    return Math.min(baseMs + Math.floor(sample * (Math.max(jitterMs, 0) + 1)), MAX_TIMER_MS);
   }
   // A hint names the room with traffic. An unknown room is counted and ignored;
   // a hintless wake falls back to draining every ready room.
@@ -34228,9 +34284,9 @@ var ResponsiveDeliveryController = class {
     await this.drainRoom(current);
   }
   // Coalescing must not swallow a requested drain. Joining an in-flight drain
-  // would lose the immediate post-replacement pass a session revision promises,
-  // because the in-flight drain may already have read past the new rows. One
-  // rerun is queued per room instead.
+  // would lose a wake, reconnect, revision, or fallback pass because the
+  // in-flight drain may already have read past the new rows. One rerun is queued
+  // per room instead.
   drainRoom(room) {
     const existing = this.drainInFlight.get(room.roomId);
     if (existing) {
@@ -36829,7 +36885,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.7";
+var MCP_CLIENT_VERSION = "0.7.8";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.8 (2026-08-06)
+
+- Reconcile durable responsive delivery after wake-stream establishment, recover total hint loss through the ADR-0059 fallback fetch, honor server timing and jitter, and route unexpected stream completion through bounded reconnect recovery (#80).
+
 ## 0.8.7 (2026-08-06)
 
 - Add strict universal reply-route normalization, route-first presentation with server-reported hop warnings, and a distinct idempotent opaque-route submission primitive without selector or broadcast fallback (#74).

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/agent-client",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/client/src/delivery.ts
+++ b/packages/client/src/delivery.ts
@@ -39,6 +39,7 @@ export type DeliveryControllerOptions = {
   maxDrainBatches?: number;
   reconnectDelayMs?: number;
   sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  random?: () => number;
   now?: () => Date;
   // Host failure policy for wake-loop errors (rate-limit parking, terminal
   // latching, footer states). Returning "stop" settles the loop without a
@@ -75,11 +76,19 @@ export type DeliveryControllerStatus = {
 const DEFAULT_MAX_HANDLER_ATTEMPTS = 3;
 const DEFAULT_MAX_DRAIN_BATCHES = 100;
 const DEFAULT_RECONNECT_MS = 5000;
-// A healthy stream that closes without delivering a single event is reopened
-// on a short pause. Instant reopen against a server that answers and closes
-// immediately would spin the loop entirely on microtasks, starving timers.
-const EMPTY_STREAM_REOPEN_MS = 250;
+// ADR-0059 safe defaults apply until the wake stream supplies operator-tuned
+// timing. Wake hints are advisory, so fallback fetch is part of correctness.
+const DEFAULT_FALLBACK_MS = 120_000;
+const DEFAULT_FALLBACK_JITTER_MS = 30_000;
+const DEFAULT_RECONNECT_JITTER_MS = 30_000;
+const MAX_TIMER_MS = 2_147_483_647;
 const MAX_REMEMBERED_KEYS = 5000;
+
+type WakeTiming = {
+  fallbackMs: number;
+  fallbackJitterMs: number;
+  reconnectJitterMs: number;
+};
 
 function deliveryKey(roomId: string, message: ResponsiveDeliveryMessage): string {
   return `${roomId}:${message.event_id}`;
@@ -100,6 +109,7 @@ export class ResponsiveDeliveryController {
   private readonly maxDrainBatches: number;
   private readonly reconnectDelayMs: number;
   private readonly sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
+  private readonly random: () => number;
   private readonly onWakeError?: (error: unknown) => "continue" | "stop" | void;
   private readonly onWakeOpen?: () => void;
   // Deduplication is keyed by (roomId, eventId) and deliberately survives
@@ -124,6 +134,11 @@ export class ResponsiveDeliveryController {
   private ignoredWakeHints = 0;
   private lastIgnoredWakeRoomId?: string;
   private lastError?: string;
+  private wakeTiming: WakeTiming = {
+    fallbackMs: DEFAULT_FALLBACK_MS,
+    fallbackJitterMs: DEFAULT_FALLBACK_JITTER_MS,
+    reconnectJitterMs: DEFAULT_RECONNECT_JITTER_MS,
+  };
 
   constructor(private readonly client: ParleAgentClient, options: DeliveryControllerOptions) {
     this.handler = options.handler;
@@ -131,6 +146,7 @@ export class ResponsiveDeliveryController {
     this.maxDrainBatches = options.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES;
     this.reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_RECONNECT_MS;
     this.sleep = options.sleep ?? defaultSleep;
+    this.random = options.random ?? Math.random;
     this.onWakeError = options.onWakeError;
     this.onWakeOpen = options.onWakeOpen;
   }
@@ -160,12 +176,12 @@ export class ResponsiveDeliveryController {
   async start(): Promise<void> {
     if (this.loop) return;
     await this.client.ensureBootstrapped(this.abort.signal);
-    // A committed session replacement invalidates the open stream. Restart it
-    // and drain immediately: the replacement participant may already have rows.
+    // A committed session replacement invalidates the old stream. The next
+    // stream opens with current membership and performs the canonical recovery
+    // drain after its subscriptions exist.
     this.unsubscribeRevision?.();
     this.unsubscribeRevision = (this.client as any).onSessionRevision?.(() => {
       this.wakeAbort?.abort();
-      void this.drainAll().catch(() => undefined);
     });
     await this.drainAll();
     // A settled loop must not read as running forever: a terminal wake error
@@ -230,55 +246,103 @@ export class ResponsiveDeliveryController {
   }
 
   private async watchLoop(): Promise<void> {
-    while (!this.abort.signal.aborted) {
-      const wakeAbort = new AbortController();
-      this.wakeAbort = wakeAbort;
-      const onAbort = () => wakeAbort.abort();
-      this.abort.signal.addEventListener("abort", onAbort, { once: true });
-      try {
-        const response = await this.client.openWakeStream(wakeAbort.signal);
-        const reader = response.body?.getReader();
-        if (!reader) throw new Error("Parle wake stream has no body");
-        this.lastError = undefined;
-        this.onWakeOpen?.();
-        // A held stream does not observe an AbortSignal on its own, so the
-        // pending read is cancelled explicitly; otherwise stop() would wait
-        // forever on a stream that never produces another frame.
-        const cancelRead = () => void reader.cancel().catch(() => undefined);
-        wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let sawEvent = false;
-        while (!wakeAbort.signal.aborted) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const parsed = parseSSEBlocks(buffer);
-          buffer = parsed.rest;
-          for (const event of parsed.events) {
-            sawEvent = true;
-            if (event.event === "wake") await this.handleWake(event.data);
-          }
-        }
-        this.lastError = undefined;
-        if (!wakeAbort.signal.aborted && !sawEvent) await this.sleep(EMPTY_STREAM_REOPEN_MS, this.abort.signal);
-      } catch (error: any) {
-        if (this.abort.signal.aborted) break;
-        // A revision-driven restart is expected, not a failure.
-        if (wakeAbort.signal.aborted) continue;
-        this.lastError = redactString(error instanceof Error ? error.message : String(error));
-        if (this.onWakeError?.(error) === "stop") return;
-        if (error instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error.action || "")) throw error;
-        const retryAfter = error instanceof ParleApiError && typeof error.retryAfterMs === "number" ? error.retryAfterMs : 0;
+    const fallbackAbort = new AbortController();
+    const abortFallback = () => fallbackAbort.abort();
+    this.abort.signal.addEventListener("abort", abortFallback, { once: true });
+    const fallback = this.fallbackLoop(fallbackAbort.signal);
+    try {
+      while (!this.abort.signal.aborted) {
+        const wakeAbort = new AbortController();
+        this.wakeAbort = wakeAbort;
+        const onAbort = () => wakeAbort.abort();
+        this.abort.signal.addEventListener("abort", onAbort, { once: true });
         try {
-          await this.sleep(Math.max(retryAfter, this.reconnectDelayMs), this.abort.signal);
-        } catch {
-          break;
+          const response = await this.client.openWakeStream(wakeAbort.signal);
+          const reader = response.body?.getReader();
+          if (!reader) throw new Error("Parle wake stream has no body");
+          // A held stream does not observe an AbortSignal on its own, so the
+          // pending read is cancelled explicitly; otherwise stop() would wait
+          // forever on a stream that never produces another frame.
+          const cancelRead = () => void reader.cancel().catch(() => undefined);
+          wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
+          // The live stream buffers hints while durable state is reconciled. This
+          // closes both the startup drain-to-subscribe race and reconnect gaps.
+          await this.drainAll();
+          if (wakeAbort.signal.aborted) continue;
+          this.lastError = undefined;
+          this.onWakeOpen?.();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (!wakeAbort.signal.aborted) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const parsed = parseSSEBlocks(buffer);
+            buffer = parsed.rest;
+            for (const event of parsed.events) {
+              if (event.event === "config") this.applyWakeConfig(event.data);
+              else if (event.event === "wake") await this.handleWake(event.data);
+            }
+          }
+          if (!wakeAbort.signal.aborted) throw new Error("Parle wake stream ended unexpectedly");
+        } catch (error: any) {
+          if (this.abort.signal.aborted) break;
+          // A revision-driven restart is expected, not a failure.
+          if (wakeAbort.signal.aborted) continue;
+          this.lastError = redactString(error instanceof Error ? error.message : String(error));
+          if (this.onWakeError?.(error) === "stop") return;
+          if (error instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error.action || "")) throw error;
+          const retryAfter = error instanceof ParleApiError && typeof error.retryAfterMs === "number" ? error.retryAfterMs : 0;
+          try {
+            await this.sleep(this.withJitter(Math.max(retryAfter, this.reconnectDelayMs), this.wakeTiming.reconnectJitterMs), this.abort.signal);
+          } catch {
+            break;
+          }
+        } finally {
+          this.abort.signal.removeEventListener("abort", onAbort);
         }
-      } finally {
-        this.abort.signal.removeEventListener("abort", onAbort);
       }
+    } finally {
+      fallbackAbort.abort();
+      await fallback;
+      this.abort.signal.removeEventListener("abort", abortFallback);
     }
+  }
+
+  private async fallbackLoop(signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      const timing = this.wakeTiming;
+      try {
+        await this.sleep(this.withJitter(timing.fallbackMs, timing.fallbackJitterMs), signal);
+      } catch {
+        return;
+      }
+      if (signal.aborted) return;
+      await this.drainAll();
+    }
+  }
+
+  private applyWakeConfig(data: string): void {
+    let config: any;
+    try {
+      config = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (!config || typeof config !== "object") return;
+    const positive = (value: unknown): value is number => Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= MAX_TIMER_MS;
+    const nonNegative = (value: unknown): value is number => Number.isSafeInteger(value) && Number(value) >= 0 && Number(value) <= MAX_TIMER_MS;
+    this.wakeTiming = {
+      fallbackMs: positive(config.fallback_ms) ? config.fallback_ms : this.wakeTiming.fallbackMs,
+      fallbackJitterMs: nonNegative(config.fallback_jitter_ms) ? config.fallback_jitter_ms : this.wakeTiming.fallbackJitterMs,
+      reconnectJitterMs: nonNegative(config.reconnect_jitter_ms) ? config.reconnect_jitter_ms : this.wakeTiming.reconnectJitterMs,
+    };
+  }
+
+  private withJitter(baseMs: number, jitterMs: number): number {
+    const random = this.random();
+    const sample = Number.isFinite(random) ? Math.min(Math.max(random, 0), 1 - Number.EPSILON) : 0;
+    return Math.min(baseMs + Math.floor(sample * (Math.max(jitterMs, 0) + 1)), MAX_TIMER_MS);
   }
 
   // A hint names the room with traffic. An unknown room is counted and ignored;
@@ -326,9 +390,9 @@ export class ResponsiveDeliveryController {
   }
 
   // Coalescing must not swallow a requested drain. Joining an in-flight drain
-  // would lose the immediate post-replacement pass a session revision promises,
-  // because the in-flight drain may already have read past the new rows. One
-  // rerun is queued per room instead.
+  // would lose a wake, reconnect, revision, or fallback pass because the
+  // in-flight drain may already have read past the new rows. One rerun is queued
+  // per room instead.
   private drainRoom(room: RoomRuntime): Promise<void> {
     const existing = this.drainInFlight.get(room.roomId);
     if (existing) {

--- a/packages/client/test/delivery.test.mjs
+++ b/packages/client/test/delivery.test.mjs
@@ -14,10 +14,15 @@ function json(body, status = 200) {
 
 // A held stream the test can push wake frames into, mirroring the real
 // server: the stream stays open and frames arrive after start() returns.
-function heldWakeStream(sink) {
+function heldWakeStream(sink, config) {
   return new Response(new ReadableStream({
     start(controller) {
-      sink.push = (event) => controller.enqueue(new TextEncoder().encode(`event: wake\ndata: ${JSON.stringify(event)}\n\n`));
+      const send = (event, data) => controller.enqueue(new TextEncoder().encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+      sink.push = (event) => send("wake", event);
+      sink.config = (value) => send("config", value);
+      sink.close = () => controller.close();
+      sink.error = (error = new Error("wake stream failed")) => controller.error(error);
+      if (config) send("config", config);
     },
   }), { status: 200 });
 }
@@ -31,10 +36,37 @@ async function eventually(condition, timeoutMs = 2000) {
   assert.fail("condition did not become true in time");
 }
 
+function controlledSleeper() {
+  const calls = [];
+  const sleep = (ms, signal) => new Promise((resolve, reject) => {
+    const entry = { ms, settled: false, release: () => {} };
+    const onAbort = () => {
+      if (entry.settled) return;
+      entry.settled = true;
+      reject(new Error("aborted"));
+    };
+    entry.release = () => {
+      if (entry.settled) return;
+      entry.settled = true;
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    calls.push(entry);
+    if (signal?.aborted) onAbort();
+    else signal?.addEventListener("abort", onAbort, { once: true });
+  });
+  const release = (predicate) => {
+    const entry = calls.find((candidate) => !candidate.settled && predicate(candidate.ms));
+    assert.ok(entry, `no pending sleep matched; saw ${JSON.stringify(calls.map(({ ms, settled }) => ({ ms, settled })))}`);
+    entry.release();
+  };
+  return { calls, sleep, release };
+}
+
 // Two configured rooms, each with its own queue of responsive rows. Rows are
 // only removed from a queue by an acknowledgement, which is what makes the
 // no-ack-on-failure and redelivery assertions meaningful.
-function harness({ rooms = { [ALPHA]: [], [BETA]: [] }, profiles = "alpha,beta", failFirstWakes = 0, retryFirstWakes = 0, instantWakes = false } = {}) {
+function harness({ rooms = { [ALPHA]: [], [BETA]: [] }, profiles = "alpha,beta", failFirstWakes = 0, retryFirstWakes = 0, emptyFirstWakes = 0, wakeConfig, onWakeOpen } = {}) {
   const wakeSink = { push: () => {} };
   const home = mkdtempSync(join(tmpdir(), "parle-delivery-home-"));
   const cwd = mkdtempSync(join(tmpdir(), "parle-delivery-project-"));
@@ -55,14 +87,15 @@ function harness({ rooms = { [ALPHA]: [], [BETA]: [] }, profiles = "alpha,beta",
     if (path.includes("/projection")) return json({ watermark: 0, messages: [] });
     if (path === "/v/agent/wake") {
       wakeOpens += 1;
+      onWakeOpen?.({ wakeOpens, queues });
       if (wakeOpens <= failFirstWakes) {
         return json({ error: { message: "wake refused terminally", action: "fix_client", scope: "request" } }, 401);
       }
       if (wakeOpens <= failFirstWakes + retryFirstWakes) {
         return json({ error: { message: "wake temporarily unavailable", action: "retry_with_backoff", scope: "request", retryable: true } }, 502);
       }
-      if (instantWakes) return new Response("", { status: 200 });
-      return heldWakeStream(wakeSink);
+      if (wakeOpens <= failFirstWakes + retryFirstWakes + emptyFirstWakes) return new Response("", { status: 200 });
+      return heldWakeStream(wakeSink, wakeConfig);
     }
     if (path.endsWith("/responsive-delivery/ack")) {
       const roomId = path.split("/")[3];
@@ -86,22 +119,55 @@ function harness({ rooms = { [ALPHA]: [], [BETA]: [] }, profiles = "alpha,beta",
     calls,
     queues,
     wake: (event) => wakeSink.push(event),
+    config: (value) => wakeSink.config(value),
+    closeWake: () => wakeSink.close(),
+    failWake: (error) => wakeSink.error(error),
     wakeOpens: () => wakeOpens,
     cleanup: () => { rmSync(home, { recursive: true, force: true }); rmSync(cwd, { recursive: true, force: true }); },
   };
 }
 
+test("the post-open drain closes the startup drain-to-subscribe race", async () => {
+  const handled = [];
+  const opens = [];
+  const h = harness({
+    rooms: { [ALPHA]: [] },
+    profiles: "alpha",
+    onWakeOpen: ({ wakeOpens, queues }) => {
+      if (wakeOpens === 1) queues.set(ALPHA, [{ seq: 1, event_id: "during-open" }]);
+    },
+  });
+  const controller = new ResponsiveDeliveryController(h.client, {
+    handler: async ({ message }) => { handled.push(message.event_id); return "handled"; },
+    onWakeOpen: () => { opens.push([...handled]); },
+  });
+  try {
+    await h.client.connect();
+    await controller.start();
+    await eventually(() => opens.length === 1);
+    assert.deepEqual(handled, ["during-open"], "the live subscription precedes the correctness drain");
+    assert.deepEqual(opens, [["during-open"]], "the host reports watching only after reconciliation");
+    assert.deepEqual(h.acks.map(([, eventId]) => eventId), ["during-open"]);
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
 test("a wake hint drains only the named room and acknowledges after handling", async () => {
   const h = harness({ rooms: { [ALPHA]: [{ seq: 1, event_id: "a1" }], [BETA]: [{ seq: 1, event_id: "b1" }] } });
   const handled = [];
+  let opened = false;
   const controller = new ResponsiveDeliveryController(h.client, {
     handler: async ({ roomId, roomHandle, profile, message }) => { handled.push([roomId, roomHandle, profile, message.event_id]); return "handled"; },
     reconnectDelayMs: 5,
+    onWakeOpen: () => { opened = true; },
   });
   try {
     await h.client.connect();
     // The startup drain reaches every ready room.
     await controller.start();
+    await eventually(() => opened);
     assert.deepEqual(handled.map(([, , , id]) => id).sort(), ["a1", "b1"]);
     assert.deepEqual(handled.find(([room]) => room === BETA), [BETA, "beta-room", "beta", "b1"]);
     // A later hint drains only the room it names.
@@ -239,6 +305,7 @@ test("a replacement session supersedes a prior alias owner without replay or wed
   writeFileSync(join(home, ".parle", "profiles"), `[alpha]\nroom_id = ${ALPHA}\nagent_token = parle_agt_alpha\n`, { mode: 0o600 });
   let generation = 4;
   let sessions = 0;
+  let wakeOpens = 0;
   const claims = [];
   let queue = [{ seq: 7, event_id: "carried" }];
   const acks = [];
@@ -258,7 +325,10 @@ test("a replacement session supersedes a prior alias owner without replay or wed
         return json({ agent_session_id: `as-${sessions}`, alias: "main", generation, address: "@p.a.main", created_at: "2026-08-01T00:00:00.000Z", expires_at: "2099-01-01T00:00:00Z" });
       }
       if (path.endsWith("/participants")) return json({ participant_id: `p-${sessions}`, room_handle: "alpha-room" }, 201);
-      if (path === "/v/agent/wake") return new Response(new ReadableStream({ start() {} }), { status: 200 });
+      if (path === "/v/agent/wake") {
+        wakeOpens += 1;
+        return new Response(new ReadableStream({ start() {} }), { status: 200 });
+      }
       if (path.includes("/projection")) return json({ watermark: 6, messages: [] });
       if (path.endsWith("/responsive-delivery/ack")) {
         const body = JSON.parse(init.body);
@@ -272,25 +342,29 @@ test("a replacement session supersedes a prior alias owner without replay or wed
     },
   });
   const handled = [];
+  const opens = [];
   const controller = new ResponsiveDeliveryController(client, {
     handler: async ({ message }) => { handled.push(message.event_id); return "handled"; },
     reconnectDelayMs: 5,
+    onWakeOpen: () => { opens.push(wakeOpens); },
   });
   try {
     await client.connect();
     assert.deepEqual(claims, [{ session: "as-1", expected: 4 }], "the replacement claims from the authoritative generation");
     assert.equal(client.runtime.sessionAlias, "main");
     await controller.start();
+    await eventually(() => opens.length === 1);
     assert.deepEqual(handled, ["carried"]);
     assert.equal(client.runtime.responsiveCursorScope, "alias", "alias-scoped continuity is preserved");
-    // Roll the session: the same alias is reclaimed and the server may replay
-    // the row to the new participant. It must not be handled twice.
-    queue = [{ seq: 7, event_id: "carried" }];
+    // Roll the session: the same alias is reclaimed, the server may replay the
+    // prior row, and new durable work is reconciled only after the successor's
+    // wake stream has opened.
+    queue = [{ seq: 7, event_id: "carried" }, { seq: 8, event_id: "after-revision" }];
     await client.performProactiveRollover();
     assert.equal(claims.length, 2);
     assert.equal(claims[1].expected, 5, "the replacement fences on the advanced generation");
-    await client.drainResponsiveDelivery(undefined, ALPHA);
-    assert.deepEqual(handled, ["carried"], "one effective action across the generation boundary");
+    await eventually(() => opens.length === 2 && handled.includes("after-revision"));
+    assert.deepEqual(handled, ["carried", "after-revision"], "one effective action per row across the generation boundary");
     assert.equal(client.runtime.sessionAlias, "main", "the route survives replacement");
   } finally {
     await controller.stop();
@@ -338,7 +412,7 @@ test("an acknowledgement failure retries the ack without re-running the handler"
   }
 });
 
-test("a session revision queues a drain instead of joining an in-flight one", async () => {
+test("a concurrent recovery request queues a drain instead of joining an in-flight one", async () => {
   const h = harness({ rooms: { [ALPHA]: [] } });
   let gate;
   let gateOpen;
@@ -366,8 +440,7 @@ test("a session revision queues a drain instead of joining an in-flight one", as
     await controller.start();
     const drainsBefore = drains;
     // Hold one drain open. It has already read an empty queue when the
-    // replacement lands, so joining it would lose the post-replacement pass
-    // a session revision promises.
+    // next recovery request lands, so joining it would lose the requested pass.
     gate = new Promise((resolve) => { gateOpen = resolve; });
     const inFlight = controller.drainForTest(ALPHA);
     await eventually(() => drains > drainsBefore);
@@ -478,20 +551,24 @@ test("a terminal wake failure settles the loop and a later start resumes deliver
 
 test("a successful internal reconnect reports the live wake stream to the host", async () => {
   const h = harness({ rooms: { [ALPHA]: [] }, profiles: "alpha", retryFirstWakes: 1 });
+  const sleeper = controlledSleeper();
   const opens = [];
   const failures = [];
   const controller = new ResponsiveDeliveryController(h.client, {
     handler: () => "handled",
     reconnectDelayMs: 5,
-    sleep: async () => {},
+    random: () => 0,
+    sleep: sleeper.sleep,
     onWakeError: (error) => { failures.push(error); return "continue"; },
     onWakeOpen: () => { opens.push(h.wakeOpens()); },
   });
   try {
     await controller.start();
-    await eventually(() => h.wakeOpens() === 2);
+    await eventually(() => sleeper.calls.some(({ ms, settled }) => ms === 5 && !settled));
+    sleeper.release((ms) => ms === 5);
+    await eventually(() => h.wakeOpens() === 2 && opens.length === 1);
     assert.equal(failures.length, 1, "the retryable failure reaches host policy");
-    assert.deepEqual(opens, [2], "only the subsequently opened live stream reports success");
+    assert.deepEqual(opens, [2], "only the subsequently opened reconciled stream reports success");
     assert.equal(controller.status().lastError, undefined, "a live stream supersedes the retryable error");
   } finally {
     await controller.stop();
@@ -499,21 +576,86 @@ test("a successful internal reconnect reports the live wake stream to the host",
   }
 });
 
-test("an event-less wake stream reopen is paced instead of spinning on microtasks", async () => {
-  const h = harness({ rooms: { [ALPHA]: [] }, profiles: "alpha", instantWakes: true });
-  const sleeps = [];
+test("a reconnect drains work queued while the stream was disconnected", async () => {
+  const h = harness({ rooms: { [ALPHA]: [] }, profiles: "alpha" });
+  const sleeper = controlledSleeper();
+  const handled = [];
+  const failures = [];
   const controller = new ResponsiveDeliveryController(h.client, {
-    handler: () => "handled",
-    sleep: async (ms) => { sleeps.push(ms); await new Promise((resolve) => setTimeout(resolve, 1)); },
+    handler: ({ message }) => { handled.push(message.event_id); return "handled"; },
+    reconnectDelayMs: 5,
+    random: () => 0,
+    sleep: sleeper.sleep,
+    onWakeError: (error) => { failures.push(error); return "continue"; },
   });
   try {
     await controller.start();
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    // Without pacing the loop reopens on resolved microtasks alone: timers
-    // starve (this settling timeout would never fire) and opens are unbounded.
-    // With pacing every reopen passes through the injected sleep first.
-    assert.ok(sleeps.length >= 1 && sleeps.every((ms) => ms === 250), `each event-less stream end sleeps before reopening, saw ${JSON.stringify(sleeps.slice(0, 3))}`);
-    assert.ok(h.wakeOpens() <= sleeps.length + 2, `wake reopen is paced, saw ${h.wakeOpens()} opens for ${sleeps.length} sleeps`);
+    await eventually(() => h.wakeOpens() === 1);
+    h.queues.set(ALPHA, [{ seq: 2, event_id: "during-disconnect" }]);
+    h.closeWake();
+    await eventually(() => sleeper.calls.some(({ ms, settled }) => ms === 5 && !settled));
+    assert.match(String(failures[0]), /ended unexpectedly/, "clean EOF is a reconnectable failure");
+    sleeper.release((ms) => ms === 5);
+    await eventually(() => handled.includes("during-disconnect"));
+    assert.equal(h.wakeOpens(), 2);
+    assert.deepEqual(h.acks.map(([, eventId]) => eventId), ["during-disconnect"]);
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
+test("fallback timing recovers all rooms after total wake-hint loss", async () => {
+  const h = harness({
+    rooms: { [ALPHA]: [], [BETA]: [] },
+    wakeConfig: { fallback_ms: 1234, fallback_jitter_ms: 100, reconnect_jitter_ms: 7 },
+  });
+  const sleeper = controlledSleeper();
+  const handled = [];
+  const controller = new ResponsiveDeliveryController(h.client, {
+    handler: ({ roomId, message }) => { handled.push([roomId, message.event_id]); return "handled"; },
+    random: () => 0.5,
+    sleep: sleeper.sleep,
+  });
+  try {
+    await controller.start();
+    await eventually(() => sleeper.calls.some(({ ms, settled }) => ms === 135000 && !settled));
+    await eventually(() => controller.status().running && h.wakeOpens() === 1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    h.queues.set(ALPHA, [{ seq: 3, event_id: "alpha-lost-hint" }]);
+    h.queues.set(BETA, [{ seq: 4, event_id: "beta-lost-hint" }]);
+    sleeper.release((ms) => ms === 135000);
+    await eventually(() => handled.length === 2);
+    assert.deepEqual(handled.sort(), [[ALPHA, "alpha-lost-hint"], [BETA, "beta-lost-hint"]].sort());
+    assert.deepEqual(h.acks.map(([roomId, eventId]) => [roomId, eventId]).sort(), handled.sort());
+    await eventually(() => sleeper.calls.some(({ ms, settled }) => ms === 1284 && !settled));
+    h.config({ fallback_ms: 0, fallback_jitter_ms: -1, reconnect_jitter_ms: "bad" });
+    sleeper.release((ms) => ms === 1284);
+    await eventually(() => sleeper.calls.filter(({ ms }) => ms === 1284).length === 2);
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
+test("an empty wake response uses the bounded reconnect path", async () => {
+  const h = harness({ rooms: { [ALPHA]: [] }, profiles: "alpha", emptyFirstWakes: 1 });
+  const sleeper = controlledSleeper();
+  const failures = [];
+  const controller = new ResponsiveDeliveryController(h.client, {
+    handler: () => "handled",
+    reconnectDelayMs: 5,
+    random: () => 0,
+    sleep: sleeper.sleep,
+    onWakeError: (error) => { failures.push(error); return "continue"; },
+  });
+  try {
+    await controller.start();
+    await eventually(() => sleeper.calls.some(({ ms, settled }) => ms === 5 && !settled));
+    assert.equal(h.wakeOpens(), 1, "EOF never spins reopen on microtasks");
+    assert.match(String(failures[0]), /ended unexpectedly/);
+    sleeper.release((ms) => ms === 5);
+    await eventually(() => h.wakeOpens() === 2);
   } finally {
     await controller.stop();
     h.cleanup();

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.7"
+        "PARLE_INTEGRATION_VERSION": "0.6.8"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.8 (2026-08-06)
+
+- Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).
+
 ## 0.6.7 (2026-08-06)
 
 - Refresh the bundled MCP runtime and responsive hook for opaque route replies and bounded-interaction warnings (#74).

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -33990,7 +33990,10 @@ function compactStatusCardFromStatus(status) {
 var DEFAULT_MAX_HANDLER_ATTEMPTS = 3;
 var DEFAULT_MAX_DRAIN_BATCHES = 100;
 var DEFAULT_RECONNECT_MS = 5e3;
-var EMPTY_STREAM_REOPEN_MS = 250;
+var DEFAULT_FALLBACK_MS = 12e4;
+var DEFAULT_FALLBACK_JITTER_MS = 3e4;
+var DEFAULT_RECONNECT_JITTER_MS = 3e4;
+var MAX_TIMER_MS = 2147483647;
 var MAX_REMEMBERED_KEYS = 5e3;
 function deliveryKey(roomId, message) {
   return `${roomId}:${message.event_id}`;
@@ -34014,6 +34017,7 @@ var ResponsiveDeliveryController = class {
   maxDrainBatches;
   reconnectDelayMs;
   sleep;
+  random;
   onWakeError;
   onWakeOpen;
   // Deduplication is keyed by (roomId, eventId) and deliberately survives
@@ -34038,6 +34042,11 @@ var ResponsiveDeliveryController = class {
   ignoredWakeHints = 0;
   lastIgnoredWakeRoomId;
   lastError;
+  wakeTiming = {
+    fallbackMs: DEFAULT_FALLBACK_MS,
+    fallbackJitterMs: DEFAULT_FALLBACK_JITTER_MS,
+    reconnectJitterMs: DEFAULT_RECONNECT_JITTER_MS
+  };
   constructor(client, options) {
     this.client = client;
     this.handler = options.handler;
@@ -34045,6 +34054,7 @@ var ResponsiveDeliveryController = class {
     this.maxDrainBatches = options.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES;
     this.reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_RECONNECT_MS;
     this.sleep = options.sleep ?? defaultSleep;
+    this.random = options.random ?? Math.random;
     this.onWakeError = options.onWakeError;
     this.onWakeOpen = options.onWakeOpen;
   }
@@ -34076,7 +34086,6 @@ var ResponsiveDeliveryController = class {
     this.unsubscribeRevision?.();
     this.unsubscribeRevision = this.client.onSessionRevision?.(() => {
       this.wakeAbort?.abort();
-      void this.drainAll().catch(() => void 0);
     });
     await this.drainAll();
     const loop = this.watchLoop();
@@ -34135,59 +34144,106 @@ var ResponsiveDeliveryController = class {
     return this.configuredRooms().filter((room) => room.state === "ready");
   }
   async watchLoop() {
-    while (!this.abort.signal.aborted) {
-      const wakeAbort = new AbortController();
-      this.wakeAbort = wakeAbort;
-      const onAbort = () => wakeAbort.abort();
-      this.abort.signal.addEventListener("abort", onAbort, { once: true });
-      try {
-        const response = await this.client.openWakeStream(wakeAbort.signal);
-        const reader = response.body?.getReader();
-        if (!reader)
-          throw new Error("Parle wake stream has no body");
-        this.lastError = void 0;
-        this.onWakeOpen?.();
-        const cancelRead = () => void reader.cancel().catch(() => void 0);
-        wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let sawEvent = false;
-        while (!wakeAbort.signal.aborted) {
-          const { value, done } = await reader.read();
-          if (done)
-            break;
-          buffer += decoder.decode(value, { stream: true });
-          const parsed = parseSSEBlocks(buffer);
-          buffer = parsed.rest;
-          for (const event of parsed.events) {
-            sawEvent = true;
-            if (event.event === "wake")
-              await this.handleWake(event.data);
-          }
-        }
-        this.lastError = void 0;
-        if (!wakeAbort.signal.aborted && !sawEvent)
-          await this.sleep(EMPTY_STREAM_REOPEN_MS, this.abort.signal);
-      } catch (error51) {
-        if (this.abort.signal.aborted)
-          break;
-        if (wakeAbort.signal.aborted)
-          continue;
-        this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
-        if (this.onWakeError?.(error51) === "stop")
-          return;
-        if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
-          throw error51;
-        const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+    const fallbackAbort = new AbortController();
+    const abortFallback = () => fallbackAbort.abort();
+    this.abort.signal.addEventListener("abort", abortFallback, { once: true });
+    const fallback = this.fallbackLoop(fallbackAbort.signal);
+    try {
+      while (!this.abort.signal.aborted) {
+        const wakeAbort = new AbortController();
+        this.wakeAbort = wakeAbort;
+        const onAbort = () => wakeAbort.abort();
+        this.abort.signal.addEventListener("abort", onAbort, { once: true });
         try {
-          await this.sleep(Math.max(retryAfter, this.reconnectDelayMs), this.abort.signal);
-        } catch {
-          break;
+          const response = await this.client.openWakeStream(wakeAbort.signal);
+          const reader = response.body?.getReader();
+          if (!reader)
+            throw new Error("Parle wake stream has no body");
+          const cancelRead = () => void reader.cancel().catch(() => void 0);
+          wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
+          await this.drainAll();
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = void 0;
+          this.onWakeOpen?.();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (!wakeAbort.signal.aborted) {
+            const { value, done } = await reader.read();
+            if (done)
+              break;
+            buffer += decoder.decode(value, { stream: true });
+            const parsed = parseSSEBlocks(buffer);
+            buffer = parsed.rest;
+            for (const event of parsed.events) {
+              if (event.event === "config")
+                this.applyWakeConfig(event.data);
+              else if (event.event === "wake")
+                await this.handleWake(event.data);
+            }
+          }
+          if (!wakeAbort.signal.aborted)
+            throw new Error("Parle wake stream ended unexpectedly");
+        } catch (error51) {
+          if (this.abort.signal.aborted)
+            break;
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
+          if (this.onWakeError?.(error51) === "stop")
+            return;
+          if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
+            throw error51;
+          const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+          try {
+            await this.sleep(this.withJitter(Math.max(retryAfter, this.reconnectDelayMs), this.wakeTiming.reconnectJitterMs), this.abort.signal);
+          } catch {
+            break;
+          }
+        } finally {
+          this.abort.signal.removeEventListener("abort", onAbort);
         }
-      } finally {
-        this.abort.signal.removeEventListener("abort", onAbort);
       }
+    } finally {
+      fallbackAbort.abort();
+      await fallback;
+      this.abort.signal.removeEventListener("abort", abortFallback);
     }
+  }
+  async fallbackLoop(signal) {
+    while (!signal.aborted) {
+      const timing = this.wakeTiming;
+      try {
+        await this.sleep(this.withJitter(timing.fallbackMs, timing.fallbackJitterMs), signal);
+      } catch {
+        return;
+      }
+      if (signal.aborted)
+        return;
+      await this.drainAll();
+    }
+  }
+  applyWakeConfig(data) {
+    let config2;
+    try {
+      config2 = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (!config2 || typeof config2 !== "object")
+      return;
+    const positive = (value) => Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= MAX_TIMER_MS;
+    const nonNegative = (value) => Number.isSafeInteger(value) && Number(value) >= 0 && Number(value) <= MAX_TIMER_MS;
+    this.wakeTiming = {
+      fallbackMs: positive(config2.fallback_ms) ? config2.fallback_ms : this.wakeTiming.fallbackMs,
+      fallbackJitterMs: nonNegative(config2.fallback_jitter_ms) ? config2.fallback_jitter_ms : this.wakeTiming.fallbackJitterMs,
+      reconnectJitterMs: nonNegative(config2.reconnect_jitter_ms) ? config2.reconnect_jitter_ms : this.wakeTiming.reconnectJitterMs
+    };
+  }
+  withJitter(baseMs, jitterMs) {
+    const random = this.random();
+    const sample = Number.isFinite(random) ? Math.min(Math.max(random, 0), 1 - Number.EPSILON) : 0;
+    return Math.min(baseMs + Math.floor(sample * (Math.max(jitterMs, 0) + 1)), MAX_TIMER_MS);
   }
   // A hint names the room with traffic. An unknown room is counted and ignored;
   // a hintless wake falls back to draining every ready room.
@@ -34228,9 +34284,9 @@ var ResponsiveDeliveryController = class {
     await this.drainRoom(current);
   }
   // Coalescing must not swallow a requested drain. Joining an in-flight drain
-  // would lose the immediate post-replacement pass a session revision promises,
-  // because the in-flight drain may already have read past the new rows. One
-  // rerun is queued per room instead.
+  // would lose a wake, reconnect, revision, or fallback pass because the
+  // in-flight drain may already have read past the new rows. One rerun is queued
+  // per room instead.
   drainRoom(room) {
     const existing = this.drainInFlight.get(room.roomId);
     if (existing) {
@@ -36829,7 +36885,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.7";
+var MCP_CLIENT_VERSION = "0.7.8";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.8 (2026-08-06)
+
+- Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).
+
 ## 0.6.7 (2026-08-06)
 
 - Refresh the bundled MCP runtime and responsive hook for opaque route replies and bounded-interaction warnings (#74).

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/skills/parle/package.json
+++ b/packages/command-code/skills/parle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-parle-mod",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/skills/parle/server/parle-mcp.js
+++ b/packages/command-code/skills/parle/server/parle-mcp.js
@@ -33990,7 +33990,10 @@ function compactStatusCardFromStatus(status) {
 var DEFAULT_MAX_HANDLER_ATTEMPTS = 3;
 var DEFAULT_MAX_DRAIN_BATCHES = 100;
 var DEFAULT_RECONNECT_MS = 5e3;
-var EMPTY_STREAM_REOPEN_MS = 250;
+var DEFAULT_FALLBACK_MS = 12e4;
+var DEFAULT_FALLBACK_JITTER_MS = 3e4;
+var DEFAULT_RECONNECT_JITTER_MS = 3e4;
+var MAX_TIMER_MS = 2147483647;
 var MAX_REMEMBERED_KEYS = 5e3;
 function deliveryKey(roomId, message) {
   return `${roomId}:${message.event_id}`;
@@ -34014,6 +34017,7 @@ var ResponsiveDeliveryController = class {
   maxDrainBatches;
   reconnectDelayMs;
   sleep;
+  random;
   onWakeError;
   onWakeOpen;
   // Deduplication is keyed by (roomId, eventId) and deliberately survives
@@ -34038,6 +34042,11 @@ var ResponsiveDeliveryController = class {
   ignoredWakeHints = 0;
   lastIgnoredWakeRoomId;
   lastError;
+  wakeTiming = {
+    fallbackMs: DEFAULT_FALLBACK_MS,
+    fallbackJitterMs: DEFAULT_FALLBACK_JITTER_MS,
+    reconnectJitterMs: DEFAULT_RECONNECT_JITTER_MS
+  };
   constructor(client, options) {
     this.client = client;
     this.handler = options.handler;
@@ -34045,6 +34054,7 @@ var ResponsiveDeliveryController = class {
     this.maxDrainBatches = options.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES;
     this.reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_RECONNECT_MS;
     this.sleep = options.sleep ?? defaultSleep;
+    this.random = options.random ?? Math.random;
     this.onWakeError = options.onWakeError;
     this.onWakeOpen = options.onWakeOpen;
   }
@@ -34076,7 +34086,6 @@ var ResponsiveDeliveryController = class {
     this.unsubscribeRevision?.();
     this.unsubscribeRevision = this.client.onSessionRevision?.(() => {
       this.wakeAbort?.abort();
-      void this.drainAll().catch(() => void 0);
     });
     await this.drainAll();
     const loop = this.watchLoop();
@@ -34135,59 +34144,106 @@ var ResponsiveDeliveryController = class {
     return this.configuredRooms().filter((room) => room.state === "ready");
   }
   async watchLoop() {
-    while (!this.abort.signal.aborted) {
-      const wakeAbort = new AbortController();
-      this.wakeAbort = wakeAbort;
-      const onAbort = () => wakeAbort.abort();
-      this.abort.signal.addEventListener("abort", onAbort, { once: true });
-      try {
-        const response = await this.client.openWakeStream(wakeAbort.signal);
-        const reader = response.body?.getReader();
-        if (!reader)
-          throw new Error("Parle wake stream has no body");
-        this.lastError = void 0;
-        this.onWakeOpen?.();
-        const cancelRead = () => void reader.cancel().catch(() => void 0);
-        wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let sawEvent = false;
-        while (!wakeAbort.signal.aborted) {
-          const { value, done } = await reader.read();
-          if (done)
-            break;
-          buffer += decoder.decode(value, { stream: true });
-          const parsed = parseSSEBlocks(buffer);
-          buffer = parsed.rest;
-          for (const event of parsed.events) {
-            sawEvent = true;
-            if (event.event === "wake")
-              await this.handleWake(event.data);
-          }
-        }
-        this.lastError = void 0;
-        if (!wakeAbort.signal.aborted && !sawEvent)
-          await this.sleep(EMPTY_STREAM_REOPEN_MS, this.abort.signal);
-      } catch (error51) {
-        if (this.abort.signal.aborted)
-          break;
-        if (wakeAbort.signal.aborted)
-          continue;
-        this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
-        if (this.onWakeError?.(error51) === "stop")
-          return;
-        if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
-          throw error51;
-        const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+    const fallbackAbort = new AbortController();
+    const abortFallback = () => fallbackAbort.abort();
+    this.abort.signal.addEventListener("abort", abortFallback, { once: true });
+    const fallback = this.fallbackLoop(fallbackAbort.signal);
+    try {
+      while (!this.abort.signal.aborted) {
+        const wakeAbort = new AbortController();
+        this.wakeAbort = wakeAbort;
+        const onAbort = () => wakeAbort.abort();
+        this.abort.signal.addEventListener("abort", onAbort, { once: true });
         try {
-          await this.sleep(Math.max(retryAfter, this.reconnectDelayMs), this.abort.signal);
-        } catch {
-          break;
+          const response = await this.client.openWakeStream(wakeAbort.signal);
+          const reader = response.body?.getReader();
+          if (!reader)
+            throw new Error("Parle wake stream has no body");
+          const cancelRead = () => void reader.cancel().catch(() => void 0);
+          wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
+          await this.drainAll();
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = void 0;
+          this.onWakeOpen?.();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (!wakeAbort.signal.aborted) {
+            const { value, done } = await reader.read();
+            if (done)
+              break;
+            buffer += decoder.decode(value, { stream: true });
+            const parsed = parseSSEBlocks(buffer);
+            buffer = parsed.rest;
+            for (const event of parsed.events) {
+              if (event.event === "config")
+                this.applyWakeConfig(event.data);
+              else if (event.event === "wake")
+                await this.handleWake(event.data);
+            }
+          }
+          if (!wakeAbort.signal.aborted)
+            throw new Error("Parle wake stream ended unexpectedly");
+        } catch (error51) {
+          if (this.abort.signal.aborted)
+            break;
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = redactString(error51 instanceof Error ? error51.message : String(error51));
+          if (this.onWakeError?.(error51) === "stop")
+            return;
+          if (error51 instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error51.action || ""))
+            throw error51;
+          const retryAfter = error51 instanceof ParleApiError && typeof error51.retryAfterMs === "number" ? error51.retryAfterMs : 0;
+          try {
+            await this.sleep(this.withJitter(Math.max(retryAfter, this.reconnectDelayMs), this.wakeTiming.reconnectJitterMs), this.abort.signal);
+          } catch {
+            break;
+          }
+        } finally {
+          this.abort.signal.removeEventListener("abort", onAbort);
         }
-      } finally {
-        this.abort.signal.removeEventListener("abort", onAbort);
       }
+    } finally {
+      fallbackAbort.abort();
+      await fallback;
+      this.abort.signal.removeEventListener("abort", abortFallback);
     }
+  }
+  async fallbackLoop(signal) {
+    while (!signal.aborted) {
+      const timing = this.wakeTiming;
+      try {
+        await this.sleep(this.withJitter(timing.fallbackMs, timing.fallbackJitterMs), signal);
+      } catch {
+        return;
+      }
+      if (signal.aborted)
+        return;
+      await this.drainAll();
+    }
+  }
+  applyWakeConfig(data) {
+    let config2;
+    try {
+      config2 = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (!config2 || typeof config2 !== "object")
+      return;
+    const positive = (value) => Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= MAX_TIMER_MS;
+    const nonNegative = (value) => Number.isSafeInteger(value) && Number(value) >= 0 && Number(value) <= MAX_TIMER_MS;
+    this.wakeTiming = {
+      fallbackMs: positive(config2.fallback_ms) ? config2.fallback_ms : this.wakeTiming.fallbackMs,
+      fallbackJitterMs: nonNegative(config2.fallback_jitter_ms) ? config2.fallback_jitter_ms : this.wakeTiming.fallbackJitterMs,
+      reconnectJitterMs: nonNegative(config2.reconnect_jitter_ms) ? config2.reconnect_jitter_ms : this.wakeTiming.reconnectJitterMs
+    };
+  }
+  withJitter(baseMs, jitterMs) {
+    const random = this.random();
+    const sample = Number.isFinite(random) ? Math.min(Math.max(random, 0), 1 - Number.EPSILON) : 0;
+    return Math.min(baseMs + Math.floor(sample * (Math.max(jitterMs, 0) + 1)), MAX_TIMER_MS);
   }
   // A hint names the room with traffic. An unknown room is counted and ignored;
   // a hintless wake falls back to draining every ready room.
@@ -34228,9 +34284,9 @@ var ResponsiveDeliveryController = class {
     await this.drainRoom(current);
   }
   // Coalescing must not swallow a requested drain. Joining an in-flight drain
-  // would lose the immediate post-replacement pass a session revision promises,
-  // because the in-flight drain may already have read past the new rows. One
-  // rerun is queued per room instead.
+  // would lose a wake, reconnect, revision, or fallback pass because the
+  // in-flight drain may already have read past the new rows. One rerun is queued
+  // per room instead.
   drainRoom(room) {
     const existing = this.drainInFlight.get(room.roomId);
     if (existing) {
@@ -36829,7 +36885,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.7";
+var MCP_CLIENT_VERSION = "0.7.8";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.8 (2026-08-06)
+
+- Refresh the embedded shared controller for post-open responsive reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).
+
 ## 0.7.7 (2026-08-06)
 
 - Add `parle_reply`, preserve opaque reply metadata through hook delivery, and render route-first instructions plus the server-reported two-replies-remaining warning (#74).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -28,7 +28,7 @@ export type ParleMcpClientLike = {
 };
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.7";
+export const MCP_CLIENT_VERSION = "0.7.8";
 const inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : undefined;
 export const MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.13 (2026-08-06)
+
+- Refresh the native shared controller so Pi recovers responsive work after reconnect or total advisory hint loss without requiring later room activity (#80).
+
 ## 0.7.12 (2026-08-06)
 
 - Add native `parle_reply`, prefer opaque routes in responsive prompts, warn at two remaining replies, and stop reconstructing author selectors from handle provenance (#74).

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -2952,7 +2952,10 @@ var ParleAccountClient = class {
 var DEFAULT_MAX_HANDLER_ATTEMPTS = 3;
 var DEFAULT_MAX_DRAIN_BATCHES = 100;
 var DEFAULT_RECONNECT_MS = 5e3;
-var EMPTY_STREAM_REOPEN_MS = 250;
+var DEFAULT_FALLBACK_MS = 12e4;
+var DEFAULT_FALLBACK_JITTER_MS = 3e4;
+var DEFAULT_RECONNECT_JITTER_MS = 3e4;
+var MAX_TIMER_MS = 2147483647;
 var MAX_REMEMBERED_KEYS = 5e3;
 function deliveryKey(roomId, message) {
   return `${roomId}:${message.event_id}`;
@@ -2976,6 +2979,7 @@ var ResponsiveDeliveryController = class {
   maxDrainBatches;
   reconnectDelayMs;
   sleep;
+  random;
   onWakeError;
   onWakeOpen;
   // Deduplication is keyed by (roomId, eventId) and deliberately survives
@@ -3000,6 +3004,11 @@ var ResponsiveDeliveryController = class {
   ignoredWakeHints = 0;
   lastIgnoredWakeRoomId;
   lastError;
+  wakeTiming = {
+    fallbackMs: DEFAULT_FALLBACK_MS,
+    fallbackJitterMs: DEFAULT_FALLBACK_JITTER_MS,
+    reconnectJitterMs: DEFAULT_RECONNECT_JITTER_MS
+  };
   constructor(client2, options) {
     this.client = client2;
     this.handler = options.handler;
@@ -3007,6 +3016,7 @@ var ResponsiveDeliveryController = class {
     this.maxDrainBatches = options.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES;
     this.reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_RECONNECT_MS;
     this.sleep = options.sleep ?? defaultSleep;
+    this.random = options.random ?? Math.random;
     this.onWakeError = options.onWakeError;
     this.onWakeOpen = options.onWakeOpen;
   }
@@ -3038,7 +3048,6 @@ var ResponsiveDeliveryController = class {
     this.unsubscribeRevision?.();
     this.unsubscribeRevision = this.client.onSessionRevision?.(() => {
       this.wakeAbort?.abort();
-      void this.drainAll().catch(() => void 0);
     });
     await this.drainAll();
     const loop = this.watchLoop();
@@ -3097,59 +3106,106 @@ var ResponsiveDeliveryController = class {
     return this.configuredRooms().filter((room) => room.state === "ready");
   }
   async watchLoop() {
-    while (!this.abort.signal.aborted) {
-      const wakeAbort = new AbortController();
-      this.wakeAbort = wakeAbort;
-      const onAbort = () => wakeAbort.abort();
-      this.abort.signal.addEventListener("abort", onAbort, { once: true });
-      try {
-        const response = await this.client.openWakeStream(wakeAbort.signal);
-        const reader = response.body?.getReader();
-        if (!reader)
-          throw new Error("Parle wake stream has no body");
-        this.lastError = void 0;
-        this.onWakeOpen?.();
-        const cancelRead = () => void reader.cancel().catch(() => void 0);
-        wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let sawEvent = false;
-        while (!wakeAbort.signal.aborted) {
-          const { value, done } = await reader.read();
-          if (done)
-            break;
-          buffer += decoder.decode(value, { stream: true });
-          const parsed = parseSSEBlocks(buffer);
-          buffer = parsed.rest;
-          for (const event of parsed.events) {
-            sawEvent = true;
-            if (event.event === "wake")
-              await this.handleWake(event.data);
-          }
-        }
-        this.lastError = void 0;
-        if (!wakeAbort.signal.aborted && !sawEvent)
-          await this.sleep(EMPTY_STREAM_REOPEN_MS, this.abort.signal);
-      } catch (error) {
-        if (this.abort.signal.aborted)
-          break;
-        if (wakeAbort.signal.aborted)
-          continue;
-        this.lastError = redactString(error instanceof Error ? error.message : String(error));
-        if (this.onWakeError?.(error) === "stop")
-          return;
-        if (error instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error.action || ""))
-          throw error;
-        const retryAfter = error instanceof ParleApiError && typeof error.retryAfterMs === "number" ? error.retryAfterMs : 0;
+    const fallbackAbort = new AbortController();
+    const abortFallback = () => fallbackAbort.abort();
+    this.abort.signal.addEventListener("abort", abortFallback, { once: true });
+    const fallback = this.fallbackLoop(fallbackAbort.signal);
+    try {
+      while (!this.abort.signal.aborted) {
+        const wakeAbort = new AbortController();
+        this.wakeAbort = wakeAbort;
+        const onAbort = () => wakeAbort.abort();
+        this.abort.signal.addEventListener("abort", onAbort, { once: true });
         try {
-          await this.sleep(Math.max(retryAfter, this.reconnectDelayMs), this.abort.signal);
-        } catch {
-          break;
+          const response = await this.client.openWakeStream(wakeAbort.signal);
+          const reader = response.body?.getReader();
+          if (!reader)
+            throw new Error("Parle wake stream has no body");
+          const cancelRead = () => void reader.cancel().catch(() => void 0);
+          wakeAbort.signal.addEventListener("abort", cancelRead, { once: true });
+          await this.drainAll();
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = void 0;
+          this.onWakeOpen?.();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (!wakeAbort.signal.aborted) {
+            const { value, done } = await reader.read();
+            if (done)
+              break;
+            buffer += decoder.decode(value, { stream: true });
+            const parsed = parseSSEBlocks(buffer);
+            buffer = parsed.rest;
+            for (const event of parsed.events) {
+              if (event.event === "config")
+                this.applyWakeConfig(event.data);
+              else if (event.event === "wake")
+                await this.handleWake(event.data);
+            }
+          }
+          if (!wakeAbort.signal.aborted)
+            throw new Error("Parle wake stream ended unexpectedly");
+        } catch (error) {
+          if (this.abort.signal.aborted)
+            break;
+          if (wakeAbort.signal.aborted)
+            continue;
+          this.lastError = redactString(error instanceof Error ? error.message : String(error));
+          if (this.onWakeError?.(error) === "stop")
+            return;
+          if (error instanceof ParleApiError && ["reauthorize", "fix_client", "stop"].includes(error.action || ""))
+            throw error;
+          const retryAfter = error instanceof ParleApiError && typeof error.retryAfterMs === "number" ? error.retryAfterMs : 0;
+          try {
+            await this.sleep(this.withJitter(Math.max(retryAfter, this.reconnectDelayMs), this.wakeTiming.reconnectJitterMs), this.abort.signal);
+          } catch {
+            break;
+          }
+        } finally {
+          this.abort.signal.removeEventListener("abort", onAbort);
         }
-      } finally {
-        this.abort.signal.removeEventListener("abort", onAbort);
       }
+    } finally {
+      fallbackAbort.abort();
+      await fallback;
+      this.abort.signal.removeEventListener("abort", abortFallback);
     }
+  }
+  async fallbackLoop(signal) {
+    while (!signal.aborted) {
+      const timing = this.wakeTiming;
+      try {
+        await this.sleep(this.withJitter(timing.fallbackMs, timing.fallbackJitterMs), signal);
+      } catch {
+        return;
+      }
+      if (signal.aborted)
+        return;
+      await this.drainAll();
+    }
+  }
+  applyWakeConfig(data) {
+    let config;
+    try {
+      config = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (!config || typeof config !== "object")
+      return;
+    const positive = (value) => Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= MAX_TIMER_MS;
+    const nonNegative = (value) => Number.isSafeInteger(value) && Number(value) >= 0 && Number(value) <= MAX_TIMER_MS;
+    this.wakeTiming = {
+      fallbackMs: positive(config.fallback_ms) ? config.fallback_ms : this.wakeTiming.fallbackMs,
+      fallbackJitterMs: nonNegative(config.fallback_jitter_ms) ? config.fallback_jitter_ms : this.wakeTiming.fallbackJitterMs,
+      reconnectJitterMs: nonNegative(config.reconnect_jitter_ms) ? config.reconnect_jitter_ms : this.wakeTiming.reconnectJitterMs
+    };
+  }
+  withJitter(baseMs, jitterMs) {
+    const random = this.random();
+    const sample = Number.isFinite(random) ? Math.min(Math.max(random, 0), 1 - Number.EPSILON) : 0;
+    return Math.min(baseMs + Math.floor(sample * (Math.max(jitterMs, 0) + 1)), MAX_TIMER_MS);
   }
   // A hint names the room with traffic. An unknown room is counted and ignored;
   // a hintless wake falls back to draining every ready room.
@@ -3190,9 +3246,9 @@ var ResponsiveDeliveryController = class {
     await this.drainRoom(current);
   }
   // Coalescing must not swallow a requested drain. Joining an in-flight drain
-  // would lose the immediate post-replacement pass a session revision promises,
-  // because the in-flight drain may already have read past the new rows. One
-  // rerun is queued per room instead.
+  // would lose a wake, reconnect, revision, or fallback pass because the
+  // in-flight drain may already have read past the new rows. One rerun is queued
+  // per room instead.
   drainRoom(room) {
     const existing = this.drainInFlight.get(room.roomId);
     if (existing) {
@@ -5545,7 +5601,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.12";
+var PI_EXTENSION_VERSION = "0.7.13";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.12";
+const PI_EXTENSION_VERSION = "0.7.13";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -746,7 +746,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.12" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.13" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1420,7 +1420,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.12");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.13");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- reconcile durable responsive delivery after every successful wake-stream establishment
- recover total advisory hint loss through the ADR-0059 fallback fetch using server timing and bounded jitter
- route unexpected stream completion through the ordinary reconnect policy
- make session revision reopen first and then reuse the canonical post-open recovery path
- refresh versions, changelogs, Pi bundle, MCP server, and maintained wrapper artifacts

## Validation

- `pnpm -F @parlehq/agent-client test`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm check:manifests`
- `pnpm check:mcp-artifacts`
- adversarial concurrency review approved the final diff

Closes #80
