### PR TITLE
Complete hardened email login with TOTP

### DIFF
--- a/docs/design/agent-token-recovery.md
+++ b/docs/design/agent-token-recovery.md
@@ -181,12 +181,13 @@ A transport failure after dispatch returns a namespaced mutation-outcome-unknown
 Pi and MCP expose the same action contract:
 
 - `start`: request a returning-login email code
-- `complete`: exchange the code and atomically persist only the protected human session
+- `complete`: exchange the code and atomically persist either the protected human session or an opaque pending-login cookie when the account requires a strong factor
+- `complete-factor`: spend TOTP against protected pending state and persist the resulting human session
 - `mint-from-session`: select an existing room and agent, mint a token, and persist a profile
 
-`complete` must never continue into minting, even when room and agent selection is unambiguous. This corrects current Pi behavior.
+`complete` must never continue into factor completion or token minting. Each proof remains one explicit confirmed operation. Pending state lives in a protected transient `login` file beside the resolved profile catalog, is never rendered, and survives only retryable TOTP refusal or infrastructure failure. Success or terminal rejection removes it.
 
-`mint-from-session` requires `confirmMutation: true` and a non-empty `reason`. It never retries automatically. Until `parlehq/parle#451` lands, a lost or malformed post-dispatch mint response remains outcome-unknown and the adapter must say so without attempting compensation.
+`complete`, `complete-factor`, and `mint-from-session` require `confirmMutation: true` and a non-empty `reason`. They never retry automatically. Until `parlehq/parle#451` lands, a lost or malformed post-dispatch mint response remains outcome-unknown and the adapter must say so without attempting compensation.
 
 ## Shared account client
 

--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.9 (2026-08-07)
+
+- Refresh account bootstrap so hardened email login can continue through TOTP without exposing pending credentials (#84, parle#705).
+
 ## 0.8.8 (2026-08-06)
 
 - Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.8"
+        "PARLE_INTEGRATION_VERSION": "0.8.9"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -32611,6 +32611,7 @@ var UUID_RE3 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 var INVITE_SECRET_RE = /^parle_inv_\S{16,256}$/;
 var INVITE_CODE_RE = /^[A-Z0-9]{6,32}$/;
 var SESSION_COOKIE_RE = /^__Host-parle_session=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
+var LOGIN_CHALLENGE_COOKIE_RE = /^__Host-parle_login=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
 var RESERVED_HANDLES = /* @__PURE__ */ new Set(["admin", "agent", "agents", "api", "me", "null", "parle", "room", "rooms", "root", "support", "system", "www"]);
 var MINT_DENIAL_NEXT_ACTION = {
   unhardened: "set a password, then enroll a second factor",
@@ -32834,6 +32835,9 @@ function validateProfileLabel(raw) {
 function sessionCookieFilePath(catalogPath) {
   return join4(dirname3(catalogPath), "session");
 }
+function pendingLoginCookieFilePath(catalogPath) {
+  return join4(dirname3(catalogPath), "login");
+}
 function assertNoSymlinkPathComponents(path) {
   const absolute = resolve(path);
   const root = parse3(absolute).root;
@@ -32887,18 +32891,18 @@ function safeProfileWritePath(path) {
     throw new Error(`Refusing to write Parle profiles because ${path} does not resolve to a file owned by the current user.`);
   return writePath;
 }
-function writeSessionCookieFile(catalogPath, cookie) {
+function writeCookieFile(catalogPath, filename, cookie) {
   const directory = ensureProfileDirectory(catalogPath);
-  const path = sessionCookieFilePath(catalogPath);
+  const path = join4(dirname3(catalogPath), filename);
   const writePath = safeProfileWritePath(join4(directory, basename(path)));
-  const tempPath = join4(dirname3(writePath), `.session.${process.pid}.${Date.now()}.tmp`);
+  const tempPath = join4(dirname3(writePath), `.${filename}.${process.pid}.${Date.now()}.tmp`);
   try {
     writeFileSync2(tempPath, `${cookie}
 `, { mode: 384, flag: "wx" });
     if (process.platform !== "win32")
       chmodSync2(tempPath, 384);
     if (ensureProfileDirectory(catalogPath) !== directory)
-      throw new Error("Parle credential directory changed during session persistence.");
+      throw new Error("Parle credential directory changed during cookie persistence.");
     safeProfileWritePath(writePath);
     renameSync3(tempPath, writePath);
     if (process.platform !== "win32")
@@ -32911,6 +32915,26 @@ function writeSessionCookieFile(catalogPath, cookie) {
     }
   }
   return path;
+}
+function writeSessionCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "session", cookie);
+}
+function writePendingLoginCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "login", cookie);
+}
+function readPendingLoginCookieFile(catalogPath) {
+  const path = safeFile(pendingLoginCookieFilePath(catalogPath), "Parle pending login credential", false);
+  const cookie = readFileSync4(path, "utf8").trim();
+  if (!LOGIN_CHALLENGE_COOKIE_RE.test(cookie))
+    throw new Error("Parle pending login credential is malformed. Remove it and restart email login.");
+  return cookie;
+}
+function removePendingLoginCookieFile(catalogPath) {
+  const path = pendingLoginCookieFilePath(catalogPath);
+  if (!existsSync3(path))
+    return;
+  safeFile(path, "Parle pending login credential", false);
+  unlinkSync2(path);
 }
 function profileSectionRange(text, label) {
   const headers = [];
@@ -33100,15 +33124,20 @@ function chooseInventoryItem(items, idKey, handleKey, label, requestedId, reques
   }
   return items.length === 1 ? items[0] : void 0;
 }
-function extractSessionCookie(headers) {
+function setCookieValues(headers) {
   const getSetCookie = headers.getSetCookie;
-  const values = typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
-  for (const value of values) {
-    const match = value.match(/(?:^|,\s*)(__Host-parle_session=[^;,\s]+)/);
+  return typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
+}
+function extractCookie(headers, name) {
+  for (const value of setCookieValues(headers)) {
+    const match = value.match(new RegExp(`(?:^|,\\s*)(${name}=[^;,\\s]+)`));
     if (match)
       return match[1];
   }
   return void 0;
+}
+function clearsCookie(headers, name) {
+  return setCookieValues(headers).some((value) => value.includes(`${name}=`) && /(?:Max-Age=0|Max-Age=-1|Expires=Thu, 01 Jan 1970)/i.test(value));
 }
 var ParleAccountClient = class {
   cwd;
@@ -33244,12 +33273,58 @@ var ParleAccountClient = class {
     const text = scrub(buffer.toString("utf8"), Object.values(body));
     if (!response.ok)
       throw new Error(`Parle email login ${path.endsWith("/start") ? "start" : "complete"} failed ${response.status}: ${truncateText(text, 4096).text}`);
-    return { json: parseJson2(text) || {}, headers: response.headers };
+    return { status: response.status, json: parseJson2(text) || {}, headers: response.headers };
+  }
+  async completeLoginFactor(config2, code, signal) {
+    const pendingCookie = readPendingLoginCookieFile(config2.catalogPath);
+    const response = await this.fetchImpl(new URL("/v/auth/login/complete", config2.apiBase), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "Parle-Version": config2.version,
+        Cookie: pendingCookie
+      },
+      body: JSON.stringify({ factor: "totp", code }),
+      signal
+    });
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_RESPONSE_BYTES2)
+      throw new Error(`Parle API response exceeded ${MAX_RESPONSE_BYTES2} bytes.`);
+    const text = scrub(buffer.toString("utf8"), [code, pendingCookie]);
+    if (response.status === 401) {
+      const terminal = clearsCookie(response.headers, "__Host-parle_login");
+      if (terminal)
+        removePendingLoginCookieFile(config2.catalogPath);
+      return {
+        status: "factor_rejected",
+        retryable: !terminal,
+        pendingLoginPreserved: !terminal,
+        secrets: "redacted; login challenge and TOTP were not returned in tool output",
+        next: terminal ? "The pending login is no longer usable. Start a new email login." : "The pending login remains usable. Retry complete-factor with the current authenticator code; do not request another email code."
+      };
+    }
+    if (!response.ok)
+      throw new Error(`Parle login factor completion failed ${response.status}: ${truncateText(text, 4096).text}`);
+    if (response.status !== 204)
+      throw new Error(`Parle login factor completion returned unexpected status ${response.status}.`);
+    const sessionCookie = extractCookie(response.headers, "__Host-parle_session");
+    if (!sessionCookie || !SESSION_COOKIE_RE.test(sessionCookie))
+      throw new Error("Parle login factor completion succeeded without a valid human session cookie. Pending state was preserved.");
+    const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+    removePendingLoginCookieFile(config2.catalogPath);
+    return {
+      status: "session_saved",
+      wroteSessionCookie: true,
+      sessionCookiePath,
+      secrets: "redacted; login challenge, TOTP, and PARLE_SESSION_COOKIE were not returned in tool output",
+      next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+    };
   }
   async login(params, signal) {
     const action = params.action || (params.code ? "complete" : "start");
     if (action !== "start" && (params.confirmMutation !== true || !params.reason?.trim()))
-      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials or minting a token.`);
+      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials, spending proof attempts, or minting a token.`);
     const config2 = resolveAccountBaseConfig(this.cwd, this.env, { allowMissingProfile: true });
     const writeCredentials = params.writeCredentials !== false;
     const profileName = params.profile || "default";
@@ -33260,8 +33335,21 @@ var ParleAccountClient = class {
       return {
         status: "code_requested",
         email: params.email,
-        next: "Call parle_login again with the same email and the code. The complete step will capture Set-Cookie and save local credentials without printing secrets."
+        next: "Call parle_login again with the same email and the code. Unhardened accounts save the human session immediately; hardened accounts continue with TOTP without requesting another email code."
       };
+    }
+    if (!writeCredentials) {
+      if (action === "complete")
+        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
+      if (action === "complete-factor")
+        throw new Error("parle_login complete-factor refuses writeCredentials=false because it would spend a TOTP attempt without durable pending-state recovery.");
+      if (action === "mint-from-session")
+        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
+    }
+    if (action === "complete-factor") {
+      if (params.factor !== "totp" || !params.code?.trim())
+        throw new Error("parle_login complete-factor requires factor='totp' and the current authenticator code.");
+      return this.completeLoginFactor(config2, params.code.trim(), signal);
     }
     let sessionCookie = config2.sessionCookie;
     if (action === "complete") {
@@ -33269,23 +33357,35 @@ var ParleAccountClient = class {
         throw new Error("parle_login complete requires email.");
       if (!params.code)
         throw new Error("parle_login complete requires code.");
-      if (!writeCredentials)
-        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
       const completed = await this.emailRequest(config2, "/v/auth/email/complete", { email: params.email, code: params.code }, signal);
-      sessionCookie = extractSessionCookie(completed.headers);
-      if (!sessionCookie)
-        throw new Error("Parle email login completed but no __Host-parle_session Set-Cookie header was present. Credential persistence cannot continue safely.");
-      const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+      sessionCookie = extractCookie(completed.headers, "__Host-parle_session");
+      if (completed.status === 201 && sessionCookie && SESSION_COOKIE_RE.test(sessionCookie)) {
+        const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+        removePendingLoginCookieFile(config2.catalogPath);
+        return {
+          status: "session_saved",
+          wroteSessionCookie: true,
+          sessionCookiePath,
+          secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
+          next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        };
+      }
+      const pendingCookie = extractCookie(completed.headers, "__Host-parle_login");
+      const factors = Array.isArray(completed.json?.factors) ? completed.json.factors.filter((factor) => typeof factor === "string") : [];
+      if (completed.status !== 202 || completed.json?.status !== "factor_required" || !pendingCookie || !LOGIN_CHALLENGE_COOKIE_RE.test(pendingCookie) || !factors.includes("totp") || typeof completed.json?.expires_at !== "string") {
+        throw new Error("Parle email login returned an invalid session-or-factor response. No credential was persisted.");
+      }
+      const pendingLoginCookiePath = writePendingLoginCookieFile(config2.catalogPath, pendingCookie);
       return {
-        status: "session_saved",
-        wroteSessionCookie: true,
-        sessionCookiePath,
-        secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
-        next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        status: "factor_required",
+        factors,
+        expires_at: completed.json.expires_at,
+        wrotePendingLoginCookie: true,
+        pendingLoginCookiePath,
+        secrets: "redacted; login challenge and email code were not returned in tool output",
+        next: "Call parle_login with action:'complete-factor', factor:'totp', and the current authenticator code. Do not request another email code."
       };
     } else if (action === "mint-from-session") {
-      if (!writeCredentials)
-        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
       preflightProfileWrite(profileName, params.force === true, config2.catalogPath);
       if (!sessionCookie)
         throw new Error(`parle_login mint-from-session requires PARLE_SESSION_COOKIE in env or .env, or a session file at ${sessionCookieFilePath(config2.catalogPath)} (written by parle_login complete).`);
@@ -36885,7 +36985,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.8";
+var MCP_CLIENT_VERSION = "0.7.9";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";
@@ -37057,10 +37157,11 @@ function createParleMcpServer(client = createMcpAgentClient(), accountClient = n
   }));
   server.registerTool("parle_login", {
     title: "Parle Login",
-    description: "Request or complete an email-code login, then separately mint a room-bound agent profile from the saved human session. Complete persists only the human session cookie. mint-from-session performs the non-idempotent token mint and profile publication. Both require confirmMutation=true plus a reason, always persist their credential, and never return a session cookie or token.",
+    description: "Request or complete an email-code login, continue a hardened login with TOTP when required, then separately mint a room-bound agent profile from the saved human session. Complete persists either the human session or an opaque pending-login cookie; complete-factor spends TOTP and promotes pending state to the human session. mint-from-session performs the non-idempotent token mint and profile publication. Credential-consuming actions require confirmMutation=true plus a reason, always persist recoverable state, and never return a cookie, proof, or token.",
     inputSchema: {
-      action: external_exports.enum(["start", "complete", "mint-from-session"]).optional(),
+      action: external_exports.enum(["start", "complete", "complete-factor", "mint-from-session"]).optional(),
       email: external_exports.string().optional(),
+      factor: external_exports.enum(["totp"]).optional(),
       code: external_exports.string().optional(),
       roomId: external_exports.string().optional(),
       roomHandle: external_exports.string().optional(),

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
       ],
       "env": {
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.8"
+        "PARLE_INTEGRATION_VERSION": "0.9.9"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.9 (2026-08-07)
+
+- Refresh account bootstrap so hardened email login can continue through TOTP without exposing pending credentials (#84, parle#705).
+
 ## 0.9.8 (2026-08-06)
 
 - Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -32611,6 +32611,7 @@ var UUID_RE3 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 var INVITE_SECRET_RE = /^parle_inv_\S{16,256}$/;
 var INVITE_CODE_RE = /^[A-Z0-9]{6,32}$/;
 var SESSION_COOKIE_RE = /^__Host-parle_session=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
+var LOGIN_CHALLENGE_COOKIE_RE = /^__Host-parle_login=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
 var RESERVED_HANDLES = /* @__PURE__ */ new Set(["admin", "agent", "agents", "api", "me", "null", "parle", "room", "rooms", "root", "support", "system", "www"]);
 var MINT_DENIAL_NEXT_ACTION = {
   unhardened: "set a password, then enroll a second factor",
@@ -32834,6 +32835,9 @@ function validateProfileLabel(raw) {
 function sessionCookieFilePath(catalogPath) {
   return join4(dirname3(catalogPath), "session");
 }
+function pendingLoginCookieFilePath(catalogPath) {
+  return join4(dirname3(catalogPath), "login");
+}
 function assertNoSymlinkPathComponents(path) {
   const absolute = resolve(path);
   const root = parse3(absolute).root;
@@ -32887,18 +32891,18 @@ function safeProfileWritePath(path) {
     throw new Error(`Refusing to write Parle profiles because ${path} does not resolve to a file owned by the current user.`);
   return writePath;
 }
-function writeSessionCookieFile(catalogPath, cookie) {
+function writeCookieFile(catalogPath, filename, cookie) {
   const directory = ensureProfileDirectory(catalogPath);
-  const path = sessionCookieFilePath(catalogPath);
+  const path = join4(dirname3(catalogPath), filename);
   const writePath = safeProfileWritePath(join4(directory, basename(path)));
-  const tempPath = join4(dirname3(writePath), `.session.${process.pid}.${Date.now()}.tmp`);
+  const tempPath = join4(dirname3(writePath), `.${filename}.${process.pid}.${Date.now()}.tmp`);
   try {
     writeFileSync2(tempPath, `${cookie}
 `, { mode: 384, flag: "wx" });
     if (process.platform !== "win32")
       chmodSync2(tempPath, 384);
     if (ensureProfileDirectory(catalogPath) !== directory)
-      throw new Error("Parle credential directory changed during session persistence.");
+      throw new Error("Parle credential directory changed during cookie persistence.");
     safeProfileWritePath(writePath);
     renameSync3(tempPath, writePath);
     if (process.platform !== "win32")
@@ -32911,6 +32915,26 @@ function writeSessionCookieFile(catalogPath, cookie) {
     }
   }
   return path;
+}
+function writeSessionCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "session", cookie);
+}
+function writePendingLoginCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "login", cookie);
+}
+function readPendingLoginCookieFile(catalogPath) {
+  const path = safeFile(pendingLoginCookieFilePath(catalogPath), "Parle pending login credential", false);
+  const cookie = readFileSync4(path, "utf8").trim();
+  if (!LOGIN_CHALLENGE_COOKIE_RE.test(cookie))
+    throw new Error("Parle pending login credential is malformed. Remove it and restart email login.");
+  return cookie;
+}
+function removePendingLoginCookieFile(catalogPath) {
+  const path = pendingLoginCookieFilePath(catalogPath);
+  if (!existsSync3(path))
+    return;
+  safeFile(path, "Parle pending login credential", false);
+  unlinkSync2(path);
 }
 function profileSectionRange(text, label) {
   const headers = [];
@@ -33100,15 +33124,20 @@ function chooseInventoryItem(items, idKey, handleKey, label, requestedId, reques
   }
   return items.length === 1 ? items[0] : void 0;
 }
-function extractSessionCookie(headers) {
+function setCookieValues(headers) {
   const getSetCookie = headers.getSetCookie;
-  const values = typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
-  for (const value of values) {
-    const match = value.match(/(?:^|,\s*)(__Host-parle_session=[^;,\s]+)/);
+  return typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
+}
+function extractCookie(headers, name) {
+  for (const value of setCookieValues(headers)) {
+    const match = value.match(new RegExp(`(?:^|,\\s*)(${name}=[^;,\\s]+)`));
     if (match)
       return match[1];
   }
   return void 0;
+}
+function clearsCookie(headers, name) {
+  return setCookieValues(headers).some((value) => value.includes(`${name}=`) && /(?:Max-Age=0|Max-Age=-1|Expires=Thu, 01 Jan 1970)/i.test(value));
 }
 var ParleAccountClient = class {
   cwd;
@@ -33244,12 +33273,58 @@ var ParleAccountClient = class {
     const text = scrub(buffer.toString("utf8"), Object.values(body));
     if (!response.ok)
       throw new Error(`Parle email login ${path.endsWith("/start") ? "start" : "complete"} failed ${response.status}: ${truncateText(text, 4096).text}`);
-    return { json: parseJson2(text) || {}, headers: response.headers };
+    return { status: response.status, json: parseJson2(text) || {}, headers: response.headers };
+  }
+  async completeLoginFactor(config2, code, signal) {
+    const pendingCookie = readPendingLoginCookieFile(config2.catalogPath);
+    const response = await this.fetchImpl(new URL("/v/auth/login/complete", config2.apiBase), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "Parle-Version": config2.version,
+        Cookie: pendingCookie
+      },
+      body: JSON.stringify({ factor: "totp", code }),
+      signal
+    });
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_RESPONSE_BYTES2)
+      throw new Error(`Parle API response exceeded ${MAX_RESPONSE_BYTES2} bytes.`);
+    const text = scrub(buffer.toString("utf8"), [code, pendingCookie]);
+    if (response.status === 401) {
+      const terminal = clearsCookie(response.headers, "__Host-parle_login");
+      if (terminal)
+        removePendingLoginCookieFile(config2.catalogPath);
+      return {
+        status: "factor_rejected",
+        retryable: !terminal,
+        pendingLoginPreserved: !terminal,
+        secrets: "redacted; login challenge and TOTP were not returned in tool output",
+        next: terminal ? "The pending login is no longer usable. Start a new email login." : "The pending login remains usable. Retry complete-factor with the current authenticator code; do not request another email code."
+      };
+    }
+    if (!response.ok)
+      throw new Error(`Parle login factor completion failed ${response.status}: ${truncateText(text, 4096).text}`);
+    if (response.status !== 204)
+      throw new Error(`Parle login factor completion returned unexpected status ${response.status}.`);
+    const sessionCookie = extractCookie(response.headers, "__Host-parle_session");
+    if (!sessionCookie || !SESSION_COOKIE_RE.test(sessionCookie))
+      throw new Error("Parle login factor completion succeeded without a valid human session cookie. Pending state was preserved.");
+    const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+    removePendingLoginCookieFile(config2.catalogPath);
+    return {
+      status: "session_saved",
+      wroteSessionCookie: true,
+      sessionCookiePath,
+      secrets: "redacted; login challenge, TOTP, and PARLE_SESSION_COOKIE were not returned in tool output",
+      next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+    };
   }
   async login(params, signal) {
     const action = params.action || (params.code ? "complete" : "start");
     if (action !== "start" && (params.confirmMutation !== true || !params.reason?.trim()))
-      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials or minting a token.`);
+      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials, spending proof attempts, or minting a token.`);
     const config2 = resolveAccountBaseConfig(this.cwd, this.env, { allowMissingProfile: true });
     const writeCredentials = params.writeCredentials !== false;
     const profileName = params.profile || "default";
@@ -33260,8 +33335,21 @@ var ParleAccountClient = class {
       return {
         status: "code_requested",
         email: params.email,
-        next: "Call parle_login again with the same email and the code. The complete step will capture Set-Cookie and save local credentials without printing secrets."
+        next: "Call parle_login again with the same email and the code. Unhardened accounts save the human session immediately; hardened accounts continue with TOTP without requesting another email code."
       };
+    }
+    if (!writeCredentials) {
+      if (action === "complete")
+        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
+      if (action === "complete-factor")
+        throw new Error("parle_login complete-factor refuses writeCredentials=false because it would spend a TOTP attempt without durable pending-state recovery.");
+      if (action === "mint-from-session")
+        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
+    }
+    if (action === "complete-factor") {
+      if (params.factor !== "totp" || !params.code?.trim())
+        throw new Error("parle_login complete-factor requires factor='totp' and the current authenticator code.");
+      return this.completeLoginFactor(config2, params.code.trim(), signal);
     }
     let sessionCookie = config2.sessionCookie;
     if (action === "complete") {
@@ -33269,23 +33357,35 @@ var ParleAccountClient = class {
         throw new Error("parle_login complete requires email.");
       if (!params.code)
         throw new Error("parle_login complete requires code.");
-      if (!writeCredentials)
-        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
       const completed = await this.emailRequest(config2, "/v/auth/email/complete", { email: params.email, code: params.code }, signal);
-      sessionCookie = extractSessionCookie(completed.headers);
-      if (!sessionCookie)
-        throw new Error("Parle email login completed but no __Host-parle_session Set-Cookie header was present. Credential persistence cannot continue safely.");
-      const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+      sessionCookie = extractCookie(completed.headers, "__Host-parle_session");
+      if (completed.status === 201 && sessionCookie && SESSION_COOKIE_RE.test(sessionCookie)) {
+        const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+        removePendingLoginCookieFile(config2.catalogPath);
+        return {
+          status: "session_saved",
+          wroteSessionCookie: true,
+          sessionCookiePath,
+          secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
+          next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        };
+      }
+      const pendingCookie = extractCookie(completed.headers, "__Host-parle_login");
+      const factors = Array.isArray(completed.json?.factors) ? completed.json.factors.filter((factor) => typeof factor === "string") : [];
+      if (completed.status !== 202 || completed.json?.status !== "factor_required" || !pendingCookie || !LOGIN_CHALLENGE_COOKIE_RE.test(pendingCookie) || !factors.includes("totp") || typeof completed.json?.expires_at !== "string") {
+        throw new Error("Parle email login returned an invalid session-or-factor response. No credential was persisted.");
+      }
+      const pendingLoginCookiePath = writePendingLoginCookieFile(config2.catalogPath, pendingCookie);
       return {
-        status: "session_saved",
-        wroteSessionCookie: true,
-        sessionCookiePath,
-        secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
-        next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        status: "factor_required",
+        factors,
+        expires_at: completed.json.expires_at,
+        wrotePendingLoginCookie: true,
+        pendingLoginCookiePath,
+        secrets: "redacted; login challenge and email code were not returned in tool output",
+        next: "Call parle_login with action:'complete-factor', factor:'totp', and the current authenticator code. Do not request another email code."
       };
     } else if (action === "mint-from-session") {
-      if (!writeCredentials)
-        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
       preflightProfileWrite(profileName, params.force === true, config2.catalogPath);
       if (!sessionCookie)
         throw new Error(`parle_login mint-from-session requires PARLE_SESSION_COOKIE in env or .env, or a session file at ${sessionCookieFilePath(config2.catalogPath)} (written by parle_login complete).`);
@@ -36885,7 +36985,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.8";
+var MCP_CLIENT_VERSION = "0.7.9";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";
@@ -37057,10 +37157,11 @@ function createParleMcpServer(client = createMcpAgentClient(), accountClient = n
   }));
   server.registerTool("parle_login", {
     title: "Parle Login",
-    description: "Request or complete an email-code login, then separately mint a room-bound agent profile from the saved human session. Complete persists only the human session cookie. mint-from-session performs the non-idempotent token mint and profile publication. Both require confirmMutation=true plus a reason, always persist their credential, and never return a session cookie or token.",
+    description: "Request or complete an email-code login, continue a hardened login with TOTP when required, then separately mint a room-bound agent profile from the saved human session. Complete persists either the human session or an opaque pending-login cookie; complete-factor spends TOTP and promotes pending state to the human session. mint-from-session performs the non-idempotent token mint and profile publication. Credential-consuming actions require confirmMutation=true plus a reason, always persist recoverable state, and never return a cookie, proof, or token.",
     inputSchema: {
-      action: external_exports.enum(["start", "complete", "mint-from-session"]).optional(),
+      action: external_exports.enum(["start", "complete", "complete-factor", "mint-from-session"]).optional(),
       email: external_exports.string().optional(),
+      factor: external_exports.enum(["totp"]).optional(),
       code: external_exports.string().optional(),
       roomId: external_exports.string().optional(),
       roomHandle: external_exports.string().optional(),

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.9 (2026-08-07)
+
+- Continue hardened email-code login through protected pending state and explicit TOTP completion without exposing cookies or proofs (#84, parle#705).
+
 ## 0.8.8 (2026-08-06)
 
 - Reconcile durable responsive delivery after wake-stream establishment, recover total hint loss through the ADR-0059 fallback fetch, honor server timing and jitter, and route unexpected stream completion through bounded reconnect recovery (#80).

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/agent-client",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/client/src/account.ts
+++ b/packages/client/src/account.ts
@@ -16,6 +16,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 const INVITE_SECRET_RE = /^parle_inv_\S{16,256}$/;
 const INVITE_CODE_RE = /^[A-Z0-9]{6,32}$/;
 const SESSION_COOKIE_RE = /^__Host-parle_session=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
+const LOGIN_CHALLENGE_COOKIE_RE = /^__Host-parle_login=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
 const RESERVED_HANDLES = new Set(["admin", "agent", "agents", "api", "me", "null", "parle", "room", "rooms", "root", "support", "system", "www"]);
 const MINT_DENIAL_NEXT_ACTION = {
   unhardened: "set a password, then enroll a second factor",
@@ -67,8 +68,9 @@ export type ConnectOwnAgentParams = {
 };
 
 export type LoginParams = {
-  action?: "start" | "complete" | "mint-from-session";
+  action?: "start" | "complete" | "complete-factor" | "mint-from-session";
   email?: string;
+  factor?: "totp";
   code?: string;
   roomId?: string;
   roomHandle?: string;
@@ -339,6 +341,10 @@ function sessionCookieFilePath(catalogPath: string): string {
   return join(dirname(catalogPath), "session");
 }
 
+function pendingLoginCookieFilePath(catalogPath: string): string {
+  return join(dirname(catalogPath), "login");
+}
+
 function assertNoSymlinkPathComponents(path: string): string {
   const absolute = resolve(path);
   const root = parse(absolute).root;
@@ -383,20 +389,42 @@ function safeProfileWritePath(path: string): string {
   return writePath;
 }
 
-function writeSessionCookieFile(catalogPath: string, cookie: string): string {
+function writeCookieFile(catalogPath: string, filename: "session" | "login", cookie: string): string {
   const directory = ensureProfileDirectory(catalogPath);
-  const path = sessionCookieFilePath(catalogPath);
+  const path = join(dirname(catalogPath), filename);
   const writePath = safeProfileWritePath(join(directory, basename(path)));
-  const tempPath = join(dirname(writePath), `.session.${process.pid}.${Date.now()}.tmp`);
+  const tempPath = join(dirname(writePath), `.${filename}.${process.pid}.${Date.now()}.tmp`);
   try {
     writeFileSync(tempPath, `${cookie}\n`, { mode: 0o600, flag: "wx" });
     if (process.platform !== "win32") chmodSync(tempPath, 0o600);
-    if (ensureProfileDirectory(catalogPath) !== directory) throw new Error("Parle credential directory changed during session persistence.");
+    if (ensureProfileDirectory(catalogPath) !== directory) throw new Error("Parle credential directory changed during cookie persistence.");
     safeProfileWritePath(writePath);
     renameSync(tempPath, writePath);
     if (process.platform !== "win32") chmodSync(writePath, 0o600);
   } finally { try { if (existsSync(tempPath)) unlinkSync(tempPath); } catch {} }
   return path;
+}
+
+function writeSessionCookieFile(catalogPath: string, cookie: string): string {
+  return writeCookieFile(catalogPath, "session", cookie);
+}
+
+function writePendingLoginCookieFile(catalogPath: string, cookie: string): string {
+  return writeCookieFile(catalogPath, "login", cookie);
+}
+
+function readPendingLoginCookieFile(catalogPath: string): string {
+  const path = safeFile(pendingLoginCookieFilePath(catalogPath), "Parle pending login credential", false);
+  const cookie = readFileSync(path, "utf8").trim();
+  if (!LOGIN_CHALLENGE_COOKIE_RE.test(cookie)) throw new Error("Parle pending login credential is malformed. Remove it and restart email login.");
+  return cookie;
+}
+
+function removePendingLoginCookieFile(catalogPath: string): void {
+  const path = pendingLoginCookieFilePath(catalogPath);
+  if (!existsSync(path)) return;
+  safeFile(path, "Parle pending login credential", false);
+  unlinkSync(path);
 }
 
 function profileSectionRange(text: string, label: string): { start: number; end: number } | undefined {
@@ -549,14 +577,21 @@ function chooseInventoryItem(items: any[], idKey: string, handleKey: string, lab
   return items.length === 1 ? items[0] : undefined;
 }
 
-function extractSessionCookie(headers: Headers): string | undefined {
+function setCookieValues(headers: Headers): string[] {
   const getSetCookie = (headers as any).getSetCookie;
-  const values = typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
-  for (const value of values) {
-    const match = value.match(/(?:^|,\s*)(__Host-parle_session=[^;,\s]+)/);
+  return typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean) as string[];
+}
+
+function extractCookie(headers: Headers, name: "__Host-parle_session" | "__Host-parle_login"): string | undefined {
+  for (const value of setCookieValues(headers)) {
+    const match = value.match(new RegExp(`(?:^|,\\s*)(${name}=[^;,\\s]+)`));
     if (match) return match[1];
   }
   return undefined;
+}
+
+function clearsCookie(headers: Headers, name: "__Host-parle_login"): boolean {
+  return setCookieValues(headers).some((value) => value.includes(`${name}=`) && /(?:Max-Age=0|Max-Age=-1|Expires=Thu, 01 Jan 1970)/i.test(value));
 }
 
 export class ParleAccountClient {
@@ -683,7 +718,7 @@ export class ParleAccountClient {
     return roomInventoryResult(active, configured, account);
   }
 
-  private async emailRequest(config: AccountBaseConfig, path: string, body: Record<string, string>, signal?: AbortSignal): Promise<{ json: any; headers: Headers }> {
+  private async emailRequest(config: AccountBaseConfig, path: string, body: Record<string, string>, signal?: AbortSignal): Promise<{ status: number; json: any; headers: Headers }> {
     const response = await this.fetchImpl(new URL(path, config.apiBase), {
       method: "POST",
       headers: { Accept: "application/json", "Content-Type": "application/json", "Parle-Version": config.version },
@@ -694,12 +729,56 @@ export class ParleAccountClient {
     if (buffer.byteLength > MAX_RESPONSE_BYTES) throw new Error(`Parle API response exceeded ${MAX_RESPONSE_BYTES} bytes.`);
     const text = scrub(buffer.toString("utf8"), Object.values(body));
     if (!response.ok) throw new Error(`Parle email login ${path.endsWith("/start") ? "start" : "complete"} failed ${response.status}: ${truncateText(text, 4096).text}`);
-    return { json: parseJson(text) || {}, headers: response.headers };
+    return { status: response.status, json: parseJson(text) || {}, headers: response.headers };
+  }
+
+  private async completeLoginFactor(config: AccountBaseConfig, code: string, signal?: AbortSignal) {
+    const pendingCookie = readPendingLoginCookieFile(config.catalogPath);
+    const response = await this.fetchImpl(new URL("/v/auth/login/complete", config.apiBase), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "Parle-Version": config.version,
+        Cookie: pendingCookie,
+      },
+      body: JSON.stringify({ factor: "totp", code }),
+      signal,
+    });
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_RESPONSE_BYTES) throw new Error(`Parle API response exceeded ${MAX_RESPONSE_BYTES} bytes.`);
+    const text = scrub(buffer.toString("utf8"), [code, pendingCookie]);
+    if (response.status === 401) {
+      const terminal = clearsCookie(response.headers, "__Host-parle_login");
+      if (terminal) removePendingLoginCookieFile(config.catalogPath);
+      return {
+        status: "factor_rejected",
+        retryable: !terminal,
+        pendingLoginPreserved: !terminal,
+        secrets: "redacted; login challenge and TOTP were not returned in tool output",
+        next: terminal
+          ? "The pending login is no longer usable. Start a new email login."
+          : "The pending login remains usable. Retry complete-factor with the current authenticator code; do not request another email code.",
+      };
+    }
+    if (!response.ok) throw new Error(`Parle login factor completion failed ${response.status}: ${truncateText(text, 4096).text}`);
+    if (response.status !== 204) throw new Error(`Parle login factor completion returned unexpected status ${response.status}.`);
+    const sessionCookie = extractCookie(response.headers, "__Host-parle_session");
+    if (!sessionCookie || !SESSION_COOKIE_RE.test(sessionCookie)) throw new Error("Parle login factor completion succeeded without a valid human session cookie. Pending state was preserved.");
+    const sessionCookiePath = writeSessionCookieFile(config.catalogPath, sessionCookie);
+    removePendingLoginCookieFile(config.catalogPath);
+    return {
+      status: "session_saved",
+      wroteSessionCookie: true,
+      sessionCookiePath,
+      secrets: "redacted; login challenge, TOTP, and PARLE_SESSION_COOKIE were not returned in tool output",
+      next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile.",
+    };
   }
 
   async login(params: LoginParams, signal?: AbortSignal) {
     const action = params.action || (params.code ? "complete" : "start");
-    if (action !== "start" && (params.confirmMutation !== true || !params.reason?.trim())) throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials or minting a token.`);
+    if (action !== "start" && (params.confirmMutation !== true || !params.reason?.trim())) throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials, spending proof attempts, or minting a token.`);
     const config = resolveAccountBaseConfig(this.cwd, this.env, { allowMissingProfile: true });
     const writeCredentials = params.writeCredentials !== false;
     const profileName = params.profile || "default";
@@ -710,28 +789,53 @@ export class ParleAccountClient {
       return {
         status: "code_requested",
         email: params.email,
-        next: "Call parle_login again with the same email and the code. The complete step will capture Set-Cookie and save local credentials without printing secrets.",
+        next: "Call parle_login again with the same email and the code. Unhardened accounts save the human session immediately; hardened accounts continue with TOTP without requesting another email code.",
       };
+    }
+
+    if (!writeCredentials) {
+      if (action === "complete") throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
+      if (action === "complete-factor") throw new Error("parle_login complete-factor refuses writeCredentials=false because it would spend a TOTP attempt without durable pending-state recovery.");
+      if (action === "mint-from-session") throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
+    }
+    if (action === "complete-factor") {
+      if (params.factor !== "totp" || !params.code?.trim()) throw new Error("parle_login complete-factor requires factor='totp' and the current authenticator code.");
+      return this.completeLoginFactor(config, params.code.trim(), signal);
     }
 
     let sessionCookie = config.sessionCookie;
     if (action === "complete") {
       if (!params.email) throw new Error("parle_login complete requires email.");
       if (!params.code) throw new Error("parle_login complete requires code.");
-      if (!writeCredentials) throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
       const completed = await this.emailRequest(config, "/v/auth/email/complete", { email: params.email, code: params.code }, signal);
-      sessionCookie = extractSessionCookie(completed.headers);
-      if (!sessionCookie) throw new Error("Parle email login completed but no __Host-parle_session Set-Cookie header was present. Credential persistence cannot continue safely.");
-      const sessionCookiePath = writeSessionCookieFile(config.catalogPath, sessionCookie);
+      sessionCookie = extractCookie(completed.headers, "__Host-parle_session");
+      if (completed.status === 201 && sessionCookie && SESSION_COOKIE_RE.test(sessionCookie)) {
+        const sessionCookiePath = writeSessionCookieFile(config.catalogPath, sessionCookie);
+        removePendingLoginCookieFile(config.catalogPath);
+        return {
+          status: "session_saved",
+          wroteSessionCookie: true,
+          sessionCookiePath,
+          secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
+          next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile.",
+        };
+      }
+      const pendingCookie = extractCookie(completed.headers, "__Host-parle_login");
+      const factors = Array.isArray(completed.json?.factors) ? completed.json.factors.filter((factor: unknown): factor is string => typeof factor === "string") : [];
+      if (completed.status !== 202 || completed.json?.status !== "factor_required" || !pendingCookie || !LOGIN_CHALLENGE_COOKIE_RE.test(pendingCookie) || !factors.includes("totp") || typeof completed.json?.expires_at !== "string") {
+        throw new Error("Parle email login returned an invalid session-or-factor response. No credential was persisted.");
+      }
+      const pendingLoginCookiePath = writePendingLoginCookieFile(config.catalogPath, pendingCookie);
       return {
-        status: "session_saved",
-        wroteSessionCookie: true,
-        sessionCookiePath,
-        secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
-        next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile.",
+        status: "factor_required",
+        factors,
+        expires_at: completed.json.expires_at,
+        wrotePendingLoginCookie: true,
+        pendingLoginCookiePath,
+        secrets: "redacted; login challenge and email code were not returned in tool output",
+        next: "Call parle_login with action:'complete-factor', factor:'totp', and the current authenticator code. Do not request another email code.",
       };
     } else if (action === "mint-from-session") {
-      if (!writeCredentials) throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
       preflightProfileWrite(profileName, params.force === true, config.catalogPath);
       if (!sessionCookie) throw new Error(`parle_login mint-from-session requires PARLE_SESSION_COOKIE in env or .env, or a session file at ${sessionCookieFilePath(config.catalogPath)} (written by parle_login complete).`);
     } else {

--- a/packages/client/test/account.test.mjs
+++ b/packages/client/test/account.test.mjs
@@ -96,6 +96,99 @@ test("login complete persists only the shared session without returning secrets 
   } finally { f.cleanup(); }
 });
 
+test("hardened email login persists pending state then promotes it with TOTP", async () => {
+  const f = loginFixture();
+  const calls = [];
+  const pending = "__Host-parle_login=parle_lgn_pending-cookie";
+  try {
+    const client = new ParleAccountClient({
+      cwd: f.cwd,
+      env: f.env,
+      fetch: async (url, init) => {
+        const path = new URL(url).pathname;
+        calls.push({ path, body: init.body && JSON.parse(init.body), cookie: init.headers.Cookie });
+        if (path === "/v/auth/email/complete") {
+          return new Response(JSON.stringify({ status: "factor_required", factors: ["totp"], expires_at: "2026-08-07T14:15:00Z" }), {
+            status: 202,
+            headers: { "Set-Cookie": `${pending}; Path=/; HttpOnly; Secure` },
+          });
+        }
+        if (path === "/v/auth/login/complete") {
+          assert.equal(init.headers.Cookie, pending);
+          return new Response(null, { status: 204, headers: { "Set-Cookie": "__Host-parle_session=parle_ses_hardened-cookie; Path=/; HttpOnly; Secure" } });
+        }
+        throw new Error(`unexpected ${path}`);
+      },
+    });
+
+    const pendingResult = await client.login({ action: "complete", confirmMutation: true, reason: "test hardened", email: "user@example.test", code: "123456" });
+    assert.equal(pendingResult.status, "factor_required");
+    assert.deepEqual(pendingResult.factors, ["totp"]);
+    assert.equal(JSON.stringify(pendingResult).includes("pending-cookie"), false);
+    assert.equal(readFileSync(join(f.home, ".parle", "login"), "utf8"), `${pending}\n`);
+    assert.equal(existsSync(join(f.home, ".parle", "session")), false);
+
+    const completed = await client.login({ action: "complete-factor", factor: "totp", confirmMutation: true, reason: "finish hardened login", code: "654321" });
+    assert.equal(completed.status, "session_saved");
+    assert.equal(JSON.stringify(completed).includes("hardened-cookie"), false);
+    assert.equal(readFileSync(join(f.home, ".parle", "session"), "utf8"), "__Host-parle_session=parle_ses_hardened-cookie\n");
+    assert.equal(existsSync(join(f.home, ".parle", "login")), false);
+    assert.deepEqual(calls.map((call) => call.path), ["/v/auth/email/complete", "/v/auth/login/complete"]);
+  } finally { f.cleanup(); }
+});
+
+test("retryable TOTP refusal preserves pending login and terminal refusal removes it", async () => {
+  const f = loginFixture();
+  const pending = "__Host-parle_login=parle_lgn_pending-cookie";
+  const state = join(f.home, ".parle");
+  mkdirSync(state, { recursive: true, mode: 0o700 });
+  writeFileSync(join(state, "login"), `${pending}\n`, { mode: 0o600 });
+  let attempts = 0;
+  try {
+    const client = new ParleAccountClient({
+      cwd: f.cwd,
+      env: f.env,
+      fetch: async (_url, init) => {
+        attempts += 1;
+        assert.equal(init.headers.Cookie, pending);
+        if (attempts === 1) return response({ error: { code: "invalid_agent_token" } }, 401);
+        return new Response(JSON.stringify({ error: { code: "invalid_agent_token" } }), {
+          status: 401,
+          headers: { "Set-Cookie": "__Host-parle_login=; Path=/; Max-Age=-1; HttpOnly; Secure" },
+        });
+      },
+    });
+
+    const retryable = await client.login({ action: "complete-factor", factor: "totp", confirmMutation: true, reason: "retry proof", code: "111111" });
+    assert.equal(retryable.status, "factor_rejected");
+    assert.equal(retryable.retryable, true);
+    assert.equal(existsSync(join(state, "login")), true);
+
+    const terminal = await client.login({ action: "complete-factor", factor: "totp", confirmMutation: true, reason: "terminal proof", code: "222222" });
+    assert.equal(terminal.status, "factor_rejected");
+    assert.equal(terminal.retryable, false);
+    assert.equal(existsSync(join(state, "login")), false);
+  } finally { f.cleanup(); }
+});
+
+test("pending login rejects unsafe custody before TOTP or network access", async () => {
+  const f = loginFixture();
+  const state = join(f.home, ".parle");
+  mkdirSync(state, { recursive: true, mode: 0o700 });
+  const pendingPath = join(state, "login");
+  writeFileSync(pendingPath, "__Host-parle_login=parle_lgn_pending-cookie\n", { mode: 0o600 });
+  if (process.platform !== "win32") chmodSync(pendingPath, 0o644);
+  let called = false;
+  try {
+    const client = new ParleAccountClient({ cwd: f.cwd, env: f.env, fetch: async () => { called = true; throw new Error("unexpected network access"); } });
+    await assert.rejects(
+      client.login({ action: "complete-factor", factor: "totp", confirmMutation: true, reason: "test unsafe custody", code: "test-proof" }),
+      process.platform === "win32" ? /unexpected network access/ : /mode 0600/,
+    );
+    if (process.platform !== "win32") assert.equal(called, false);
+  } finally { f.cleanup(); }
+});
+
 test("login credential mutations require explicit confirmation and reason before network access", async () => {
   const f = loginFixture();
   let called = false;

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.8"
+        "PARLE_INTEGRATION_VERSION": "0.6.9"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.9 (2026-08-07)
+
+- Refresh account bootstrap so hardened email login can continue through TOTP without exposing pending credentials (#84, parle#705).
+
 ## 0.6.8 (2026-08-06)
 
 - Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -32611,6 +32611,7 @@ var UUID_RE3 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 var INVITE_SECRET_RE = /^parle_inv_\S{16,256}$/;
 var INVITE_CODE_RE = /^[A-Z0-9]{6,32}$/;
 var SESSION_COOKIE_RE = /^__Host-parle_session=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
+var LOGIN_CHALLENGE_COOKIE_RE = /^__Host-parle_login=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
 var RESERVED_HANDLES = /* @__PURE__ */ new Set(["admin", "agent", "agents", "api", "me", "null", "parle", "room", "rooms", "root", "support", "system", "www"]);
 var MINT_DENIAL_NEXT_ACTION = {
   unhardened: "set a password, then enroll a second factor",
@@ -32834,6 +32835,9 @@ function validateProfileLabel(raw) {
 function sessionCookieFilePath(catalogPath) {
   return join4(dirname3(catalogPath), "session");
 }
+function pendingLoginCookieFilePath(catalogPath) {
+  return join4(dirname3(catalogPath), "login");
+}
 function assertNoSymlinkPathComponents(path) {
   const absolute = resolve(path);
   const root = parse3(absolute).root;
@@ -32887,18 +32891,18 @@ function safeProfileWritePath(path) {
     throw new Error(`Refusing to write Parle profiles because ${path} does not resolve to a file owned by the current user.`);
   return writePath;
 }
-function writeSessionCookieFile(catalogPath, cookie) {
+function writeCookieFile(catalogPath, filename, cookie) {
   const directory = ensureProfileDirectory(catalogPath);
-  const path = sessionCookieFilePath(catalogPath);
+  const path = join4(dirname3(catalogPath), filename);
   const writePath = safeProfileWritePath(join4(directory, basename(path)));
-  const tempPath = join4(dirname3(writePath), `.session.${process.pid}.${Date.now()}.tmp`);
+  const tempPath = join4(dirname3(writePath), `.${filename}.${process.pid}.${Date.now()}.tmp`);
   try {
     writeFileSync2(tempPath, `${cookie}
 `, { mode: 384, flag: "wx" });
     if (process.platform !== "win32")
       chmodSync2(tempPath, 384);
     if (ensureProfileDirectory(catalogPath) !== directory)
-      throw new Error("Parle credential directory changed during session persistence.");
+      throw new Error("Parle credential directory changed during cookie persistence.");
     safeProfileWritePath(writePath);
     renameSync3(tempPath, writePath);
     if (process.platform !== "win32")
@@ -32911,6 +32915,26 @@ function writeSessionCookieFile(catalogPath, cookie) {
     }
   }
   return path;
+}
+function writeSessionCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "session", cookie);
+}
+function writePendingLoginCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "login", cookie);
+}
+function readPendingLoginCookieFile(catalogPath) {
+  const path = safeFile(pendingLoginCookieFilePath(catalogPath), "Parle pending login credential", false);
+  const cookie = readFileSync4(path, "utf8").trim();
+  if (!LOGIN_CHALLENGE_COOKIE_RE.test(cookie))
+    throw new Error("Parle pending login credential is malformed. Remove it and restart email login.");
+  return cookie;
+}
+function removePendingLoginCookieFile(catalogPath) {
+  const path = pendingLoginCookieFilePath(catalogPath);
+  if (!existsSync3(path))
+    return;
+  safeFile(path, "Parle pending login credential", false);
+  unlinkSync2(path);
 }
 function profileSectionRange(text, label) {
   const headers = [];
@@ -33100,15 +33124,20 @@ function chooseInventoryItem(items, idKey, handleKey, label, requestedId, reques
   }
   return items.length === 1 ? items[0] : void 0;
 }
-function extractSessionCookie(headers) {
+function setCookieValues(headers) {
   const getSetCookie = headers.getSetCookie;
-  const values = typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
-  for (const value of values) {
-    const match = value.match(/(?:^|,\s*)(__Host-parle_session=[^;,\s]+)/);
+  return typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
+}
+function extractCookie(headers, name) {
+  for (const value of setCookieValues(headers)) {
+    const match = value.match(new RegExp(`(?:^|,\\s*)(${name}=[^;,\\s]+)`));
     if (match)
       return match[1];
   }
   return void 0;
+}
+function clearsCookie(headers, name) {
+  return setCookieValues(headers).some((value) => value.includes(`${name}=`) && /(?:Max-Age=0|Max-Age=-1|Expires=Thu, 01 Jan 1970)/i.test(value));
 }
 var ParleAccountClient = class {
   cwd;
@@ -33244,12 +33273,58 @@ var ParleAccountClient = class {
     const text = scrub(buffer.toString("utf8"), Object.values(body));
     if (!response.ok)
       throw new Error(`Parle email login ${path.endsWith("/start") ? "start" : "complete"} failed ${response.status}: ${truncateText(text, 4096).text}`);
-    return { json: parseJson2(text) || {}, headers: response.headers };
+    return { status: response.status, json: parseJson2(text) || {}, headers: response.headers };
+  }
+  async completeLoginFactor(config2, code, signal) {
+    const pendingCookie = readPendingLoginCookieFile(config2.catalogPath);
+    const response = await this.fetchImpl(new URL("/v/auth/login/complete", config2.apiBase), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "Parle-Version": config2.version,
+        Cookie: pendingCookie
+      },
+      body: JSON.stringify({ factor: "totp", code }),
+      signal
+    });
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_RESPONSE_BYTES2)
+      throw new Error(`Parle API response exceeded ${MAX_RESPONSE_BYTES2} bytes.`);
+    const text = scrub(buffer.toString("utf8"), [code, pendingCookie]);
+    if (response.status === 401) {
+      const terminal = clearsCookie(response.headers, "__Host-parle_login");
+      if (terminal)
+        removePendingLoginCookieFile(config2.catalogPath);
+      return {
+        status: "factor_rejected",
+        retryable: !terminal,
+        pendingLoginPreserved: !terminal,
+        secrets: "redacted; login challenge and TOTP were not returned in tool output",
+        next: terminal ? "The pending login is no longer usable. Start a new email login." : "The pending login remains usable. Retry complete-factor with the current authenticator code; do not request another email code."
+      };
+    }
+    if (!response.ok)
+      throw new Error(`Parle login factor completion failed ${response.status}: ${truncateText(text, 4096).text}`);
+    if (response.status !== 204)
+      throw new Error(`Parle login factor completion returned unexpected status ${response.status}.`);
+    const sessionCookie = extractCookie(response.headers, "__Host-parle_session");
+    if (!sessionCookie || !SESSION_COOKIE_RE.test(sessionCookie))
+      throw new Error("Parle login factor completion succeeded without a valid human session cookie. Pending state was preserved.");
+    const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+    removePendingLoginCookieFile(config2.catalogPath);
+    return {
+      status: "session_saved",
+      wroteSessionCookie: true,
+      sessionCookiePath,
+      secrets: "redacted; login challenge, TOTP, and PARLE_SESSION_COOKIE were not returned in tool output",
+      next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+    };
   }
   async login(params, signal) {
     const action = params.action || (params.code ? "complete" : "start");
     if (action !== "start" && (params.confirmMutation !== true || !params.reason?.trim()))
-      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials or minting a token.`);
+      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials, spending proof attempts, or minting a token.`);
     const config2 = resolveAccountBaseConfig(this.cwd, this.env, { allowMissingProfile: true });
     const writeCredentials = params.writeCredentials !== false;
     const profileName = params.profile || "default";
@@ -33260,8 +33335,21 @@ var ParleAccountClient = class {
       return {
         status: "code_requested",
         email: params.email,
-        next: "Call parle_login again with the same email and the code. The complete step will capture Set-Cookie and save local credentials without printing secrets."
+        next: "Call parle_login again with the same email and the code. Unhardened accounts save the human session immediately; hardened accounts continue with TOTP without requesting another email code."
       };
+    }
+    if (!writeCredentials) {
+      if (action === "complete")
+        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
+      if (action === "complete-factor")
+        throw new Error("parle_login complete-factor refuses writeCredentials=false because it would spend a TOTP attempt without durable pending-state recovery.");
+      if (action === "mint-from-session")
+        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
+    }
+    if (action === "complete-factor") {
+      if (params.factor !== "totp" || !params.code?.trim())
+        throw new Error("parle_login complete-factor requires factor='totp' and the current authenticator code.");
+      return this.completeLoginFactor(config2, params.code.trim(), signal);
     }
     let sessionCookie = config2.sessionCookie;
     if (action === "complete") {
@@ -33269,23 +33357,35 @@ var ParleAccountClient = class {
         throw new Error("parle_login complete requires email.");
       if (!params.code)
         throw new Error("parle_login complete requires code.");
-      if (!writeCredentials)
-        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
       const completed = await this.emailRequest(config2, "/v/auth/email/complete", { email: params.email, code: params.code }, signal);
-      sessionCookie = extractSessionCookie(completed.headers);
-      if (!sessionCookie)
-        throw new Error("Parle email login completed but no __Host-parle_session Set-Cookie header was present. Credential persistence cannot continue safely.");
-      const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+      sessionCookie = extractCookie(completed.headers, "__Host-parle_session");
+      if (completed.status === 201 && sessionCookie && SESSION_COOKIE_RE.test(sessionCookie)) {
+        const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+        removePendingLoginCookieFile(config2.catalogPath);
+        return {
+          status: "session_saved",
+          wroteSessionCookie: true,
+          sessionCookiePath,
+          secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
+          next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        };
+      }
+      const pendingCookie = extractCookie(completed.headers, "__Host-parle_login");
+      const factors = Array.isArray(completed.json?.factors) ? completed.json.factors.filter((factor) => typeof factor === "string") : [];
+      if (completed.status !== 202 || completed.json?.status !== "factor_required" || !pendingCookie || !LOGIN_CHALLENGE_COOKIE_RE.test(pendingCookie) || !factors.includes("totp") || typeof completed.json?.expires_at !== "string") {
+        throw new Error("Parle email login returned an invalid session-or-factor response. No credential was persisted.");
+      }
+      const pendingLoginCookiePath = writePendingLoginCookieFile(config2.catalogPath, pendingCookie);
       return {
-        status: "session_saved",
-        wroteSessionCookie: true,
-        sessionCookiePath,
-        secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
-        next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        status: "factor_required",
+        factors,
+        expires_at: completed.json.expires_at,
+        wrotePendingLoginCookie: true,
+        pendingLoginCookiePath,
+        secrets: "redacted; login challenge and email code were not returned in tool output",
+        next: "Call parle_login with action:'complete-factor', factor:'totp', and the current authenticator code. Do not request another email code."
       };
     } else if (action === "mint-from-session") {
-      if (!writeCredentials)
-        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
       preflightProfileWrite(profileName, params.force === true, config2.catalogPath);
       if (!sessionCookie)
         throw new Error(`parle_login mint-from-session requires PARLE_SESSION_COOKIE in env or .env, or a session file at ${sessionCookieFilePath(config2.catalogPath)} (written by parle_login complete).`);
@@ -36885,7 +36985,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.8";
+var MCP_CLIENT_VERSION = "0.7.9";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";
@@ -37057,10 +37157,11 @@ function createParleMcpServer(client = createMcpAgentClient(), accountClient = n
   }));
   server.registerTool("parle_login", {
     title: "Parle Login",
-    description: "Request or complete an email-code login, then separately mint a room-bound agent profile from the saved human session. Complete persists only the human session cookie. mint-from-session performs the non-idempotent token mint and profile publication. Both require confirmMutation=true plus a reason, always persist their credential, and never return a session cookie or token.",
+    description: "Request or complete an email-code login, continue a hardened login with TOTP when required, then separately mint a room-bound agent profile from the saved human session. Complete persists either the human session or an opaque pending-login cookie; complete-factor spends TOTP and promotes pending state to the human session. mint-from-session performs the non-idempotent token mint and profile publication. Credential-consuming actions require confirmMutation=true plus a reason, always persist recoverable state, and never return a cookie, proof, or token.",
     inputSchema: {
-      action: external_exports.enum(["start", "complete", "mint-from-session"]).optional(),
+      action: external_exports.enum(["start", "complete", "complete-factor", "mint-from-session"]).optional(),
       email: external_exports.string().optional(),
+      factor: external_exports.enum(["totp"]).optional(),
       code: external_exports.string().optional(),
       roomId: external_exports.string().optional(),
       roomHandle: external_exports.string().optional(),

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.9 (2026-08-07)
+
+- Refresh account bootstrap so hardened email login can continue through TOTP without exposing pending credentials (#84, parle#705).
+
 ## 0.6.8 (2026-08-06)
 
 - Refresh responsive delivery for post-open reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/skills/parle/package.json
+++ b/packages/command-code/skills/parle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-parle-mod",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/skills/parle/server/parle-mcp.js
+++ b/packages/command-code/skills/parle/server/parle-mcp.js
@@ -32611,6 +32611,7 @@ var UUID_RE3 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 var INVITE_SECRET_RE = /^parle_inv_\S{16,256}$/;
 var INVITE_CODE_RE = /^[A-Z0-9]{6,32}$/;
 var SESSION_COOKIE_RE = /^__Host-parle_session=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
+var LOGIN_CHALLENGE_COOKIE_RE = /^__Host-parle_login=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
 var RESERVED_HANDLES = /* @__PURE__ */ new Set(["admin", "agent", "agents", "api", "me", "null", "parle", "room", "rooms", "root", "support", "system", "www"]);
 var MINT_DENIAL_NEXT_ACTION = {
   unhardened: "set a password, then enroll a second factor",
@@ -32834,6 +32835,9 @@ function validateProfileLabel(raw) {
 function sessionCookieFilePath(catalogPath) {
   return join4(dirname3(catalogPath), "session");
 }
+function pendingLoginCookieFilePath(catalogPath) {
+  return join4(dirname3(catalogPath), "login");
+}
 function assertNoSymlinkPathComponents(path) {
   const absolute = resolve(path);
   const root = parse3(absolute).root;
@@ -32887,18 +32891,18 @@ function safeProfileWritePath(path) {
     throw new Error(`Refusing to write Parle profiles because ${path} does not resolve to a file owned by the current user.`);
   return writePath;
 }
-function writeSessionCookieFile(catalogPath, cookie) {
+function writeCookieFile(catalogPath, filename, cookie) {
   const directory = ensureProfileDirectory(catalogPath);
-  const path = sessionCookieFilePath(catalogPath);
+  const path = join4(dirname3(catalogPath), filename);
   const writePath = safeProfileWritePath(join4(directory, basename(path)));
-  const tempPath = join4(dirname3(writePath), `.session.${process.pid}.${Date.now()}.tmp`);
+  const tempPath = join4(dirname3(writePath), `.${filename}.${process.pid}.${Date.now()}.tmp`);
   try {
     writeFileSync2(tempPath, `${cookie}
 `, { mode: 384, flag: "wx" });
     if (process.platform !== "win32")
       chmodSync2(tempPath, 384);
     if (ensureProfileDirectory(catalogPath) !== directory)
-      throw new Error("Parle credential directory changed during session persistence.");
+      throw new Error("Parle credential directory changed during cookie persistence.");
     safeProfileWritePath(writePath);
     renameSync3(tempPath, writePath);
     if (process.platform !== "win32")
@@ -32911,6 +32915,26 @@ function writeSessionCookieFile(catalogPath, cookie) {
     }
   }
   return path;
+}
+function writeSessionCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "session", cookie);
+}
+function writePendingLoginCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "login", cookie);
+}
+function readPendingLoginCookieFile(catalogPath) {
+  const path = safeFile(pendingLoginCookieFilePath(catalogPath), "Parle pending login credential", false);
+  const cookie = readFileSync4(path, "utf8").trim();
+  if (!LOGIN_CHALLENGE_COOKIE_RE.test(cookie))
+    throw new Error("Parle pending login credential is malformed. Remove it and restart email login.");
+  return cookie;
+}
+function removePendingLoginCookieFile(catalogPath) {
+  const path = pendingLoginCookieFilePath(catalogPath);
+  if (!existsSync3(path))
+    return;
+  safeFile(path, "Parle pending login credential", false);
+  unlinkSync2(path);
 }
 function profileSectionRange(text, label) {
   const headers = [];
@@ -33100,15 +33124,20 @@ function chooseInventoryItem(items, idKey, handleKey, label, requestedId, reques
   }
   return items.length === 1 ? items[0] : void 0;
 }
-function extractSessionCookie(headers) {
+function setCookieValues(headers) {
   const getSetCookie = headers.getSetCookie;
-  const values = typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
-  for (const value of values) {
-    const match = value.match(/(?:^|,\s*)(__Host-parle_session=[^;,\s]+)/);
+  return typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
+}
+function extractCookie(headers, name) {
+  for (const value of setCookieValues(headers)) {
+    const match = value.match(new RegExp(`(?:^|,\\s*)(${name}=[^;,\\s]+)`));
     if (match)
       return match[1];
   }
   return void 0;
+}
+function clearsCookie(headers, name) {
+  return setCookieValues(headers).some((value) => value.includes(`${name}=`) && /(?:Max-Age=0|Max-Age=-1|Expires=Thu, 01 Jan 1970)/i.test(value));
 }
 var ParleAccountClient = class {
   cwd;
@@ -33244,12 +33273,58 @@ var ParleAccountClient = class {
     const text = scrub(buffer.toString("utf8"), Object.values(body));
     if (!response.ok)
       throw new Error(`Parle email login ${path.endsWith("/start") ? "start" : "complete"} failed ${response.status}: ${truncateText(text, 4096).text}`);
-    return { json: parseJson2(text) || {}, headers: response.headers };
+    return { status: response.status, json: parseJson2(text) || {}, headers: response.headers };
+  }
+  async completeLoginFactor(config2, code, signal) {
+    const pendingCookie = readPendingLoginCookieFile(config2.catalogPath);
+    const response = await this.fetchImpl(new URL("/v/auth/login/complete", config2.apiBase), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "Parle-Version": config2.version,
+        Cookie: pendingCookie
+      },
+      body: JSON.stringify({ factor: "totp", code }),
+      signal
+    });
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_RESPONSE_BYTES2)
+      throw new Error(`Parle API response exceeded ${MAX_RESPONSE_BYTES2} bytes.`);
+    const text = scrub(buffer.toString("utf8"), [code, pendingCookie]);
+    if (response.status === 401) {
+      const terminal = clearsCookie(response.headers, "__Host-parle_login");
+      if (terminal)
+        removePendingLoginCookieFile(config2.catalogPath);
+      return {
+        status: "factor_rejected",
+        retryable: !terminal,
+        pendingLoginPreserved: !terminal,
+        secrets: "redacted; login challenge and TOTP were not returned in tool output",
+        next: terminal ? "The pending login is no longer usable. Start a new email login." : "The pending login remains usable. Retry complete-factor with the current authenticator code; do not request another email code."
+      };
+    }
+    if (!response.ok)
+      throw new Error(`Parle login factor completion failed ${response.status}: ${truncateText(text, 4096).text}`);
+    if (response.status !== 204)
+      throw new Error(`Parle login factor completion returned unexpected status ${response.status}.`);
+    const sessionCookie = extractCookie(response.headers, "__Host-parle_session");
+    if (!sessionCookie || !SESSION_COOKIE_RE.test(sessionCookie))
+      throw new Error("Parle login factor completion succeeded without a valid human session cookie. Pending state was preserved.");
+    const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+    removePendingLoginCookieFile(config2.catalogPath);
+    return {
+      status: "session_saved",
+      wroteSessionCookie: true,
+      sessionCookiePath,
+      secrets: "redacted; login challenge, TOTP, and PARLE_SESSION_COOKIE were not returned in tool output",
+      next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+    };
   }
   async login(params, signal) {
     const action = params.action || (params.code ? "complete" : "start");
     if (action !== "start" && (params.confirmMutation !== true || !params.reason?.trim()))
-      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials or minting a token.`);
+      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials, spending proof attempts, or minting a token.`);
     const config2 = resolveAccountBaseConfig(this.cwd, this.env, { allowMissingProfile: true });
     const writeCredentials = params.writeCredentials !== false;
     const profileName = params.profile || "default";
@@ -33260,8 +33335,21 @@ var ParleAccountClient = class {
       return {
         status: "code_requested",
         email: params.email,
-        next: "Call parle_login again with the same email and the code. The complete step will capture Set-Cookie and save local credentials without printing secrets."
+        next: "Call parle_login again with the same email and the code. Unhardened accounts save the human session immediately; hardened accounts continue with TOTP without requesting another email code."
       };
+    }
+    if (!writeCredentials) {
+      if (action === "complete")
+        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
+      if (action === "complete-factor")
+        throw new Error("parle_login complete-factor refuses writeCredentials=false because it would spend a TOTP attempt without durable pending-state recovery.");
+      if (action === "mint-from-session")
+        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
+    }
+    if (action === "complete-factor") {
+      if (params.factor !== "totp" || !params.code?.trim())
+        throw new Error("parle_login complete-factor requires factor='totp' and the current authenticator code.");
+      return this.completeLoginFactor(config2, params.code.trim(), signal);
     }
     let sessionCookie = config2.sessionCookie;
     if (action === "complete") {
@@ -33269,23 +33357,35 @@ var ParleAccountClient = class {
         throw new Error("parle_login complete requires email.");
       if (!params.code)
         throw new Error("parle_login complete requires code.");
-      if (!writeCredentials)
-        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
       const completed = await this.emailRequest(config2, "/v/auth/email/complete", { email: params.email, code: params.code }, signal);
-      sessionCookie = extractSessionCookie(completed.headers);
-      if (!sessionCookie)
-        throw new Error("Parle email login completed but no __Host-parle_session Set-Cookie header was present. Credential persistence cannot continue safely.");
-      const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+      sessionCookie = extractCookie(completed.headers, "__Host-parle_session");
+      if (completed.status === 201 && sessionCookie && SESSION_COOKIE_RE.test(sessionCookie)) {
+        const sessionCookiePath = writeSessionCookieFile(config2.catalogPath, sessionCookie);
+        removePendingLoginCookieFile(config2.catalogPath);
+        return {
+          status: "session_saved",
+          wroteSessionCookie: true,
+          sessionCookiePath,
+          secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
+          next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        };
+      }
+      const pendingCookie = extractCookie(completed.headers, "__Host-parle_login");
+      const factors = Array.isArray(completed.json?.factors) ? completed.json.factors.filter((factor) => typeof factor === "string") : [];
+      if (completed.status !== 202 || completed.json?.status !== "factor_required" || !pendingCookie || !LOGIN_CHALLENGE_COOKIE_RE.test(pendingCookie) || !factors.includes("totp") || typeof completed.json?.expires_at !== "string") {
+        throw new Error("Parle email login returned an invalid session-or-factor response. No credential was persisted.");
+      }
+      const pendingLoginCookiePath = writePendingLoginCookieFile(config2.catalogPath, pendingCookie);
       return {
-        status: "session_saved",
-        wroteSessionCookie: true,
-        sessionCookiePath,
-        secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
-        next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        status: "factor_required",
+        factors,
+        expires_at: completed.json.expires_at,
+        wrotePendingLoginCookie: true,
+        pendingLoginCookiePath,
+        secrets: "redacted; login challenge and email code were not returned in tool output",
+        next: "Call parle_login with action:'complete-factor', factor:'totp', and the current authenticator code. Do not request another email code."
       };
     } else if (action === "mint-from-session") {
-      if (!writeCredentials)
-        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
       preflightProfileWrite(profileName, params.force === true, config2.catalogPath);
       if (!sessionCookie)
         throw new Error(`parle_login mint-from-session requires PARLE_SESSION_COOKIE in env or .env, or a session file at ${sessionCookieFilePath(config2.catalogPath)} (written by parle_login complete).`);
@@ -36885,7 +36985,7 @@ var HookDeliveryBridge = class {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.8";
+var MCP_CLIENT_VERSION = "0.7.9";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 var WAIT_TEXT = "waitSeconds is a bounded single wait for an explicit tool call. Do not loop on it as a watcher. Responsive delivery uses /v/agent/wake SSE, then responsive-delivery?wait=0.";
@@ -37057,10 +37157,11 @@ function createParleMcpServer(client = createMcpAgentClient(), accountClient = n
   }));
   server.registerTool("parle_login", {
     title: "Parle Login",
-    description: "Request or complete an email-code login, then separately mint a room-bound agent profile from the saved human session. Complete persists only the human session cookie. mint-from-session performs the non-idempotent token mint and profile publication. Both require confirmMutation=true plus a reason, always persist their credential, and never return a session cookie or token.",
+    description: "Request or complete an email-code login, continue a hardened login with TOTP when required, then separately mint a room-bound agent profile from the saved human session. Complete persists either the human session or an opaque pending-login cookie; complete-factor spends TOTP and promotes pending state to the human session. mint-from-session performs the non-idempotent token mint and profile publication. Credential-consuming actions require confirmMutation=true plus a reason, always persist recoverable state, and never return a cookie, proof, or token.",
     inputSchema: {
-      action: external_exports.enum(["start", "complete", "mint-from-session"]).optional(),
+      action: external_exports.enum(["start", "complete", "complete-factor", "mint-from-session"]).optional(),
       email: external_exports.string().optional(),
+      factor: external_exports.enum(["totp"]).optional(),
       code: external_exports.string().optional(),
       roomId: external_exports.string().optional(),
       roomHandle: external_exports.string().optional(),

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.9 (2026-08-07)
+
+- Add the shared `complete-factor` login action so hardened accounts can finish credential bootstrap with TOTP (#84, parle#705).
+
 ## 0.7.8 (2026-08-06)
 
 - Refresh the embedded shared controller for post-open responsive reconciliation, ADR-0059 fallback fetch, and bounded reconnect recovery (#80).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -28,7 +28,7 @@ export type ParleMcpClientLike = {
 };
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.8";
+export const MCP_CLIENT_VERSION = "0.7.9";
 const inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : undefined;
 export const MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 
@@ -247,10 +247,11 @@ export function createParleMcpServer(
 
   server.registerTool("parle_login", {
     title: "Parle Login",
-    description: "Request or complete an email-code login, then separately mint a room-bound agent profile from the saved human session. Complete persists only the human session cookie. mint-from-session performs the non-idempotent token mint and profile publication. Both require confirmMutation=true plus a reason, always persist their credential, and never return a session cookie or token.",
+    description: "Request or complete an email-code login, continue a hardened login with TOTP when required, then separately mint a room-bound agent profile from the saved human session. Complete persists either the human session or an opaque pending-login cookie; complete-factor spends TOTP and promotes pending state to the human session. mint-from-session performs the non-idempotent token mint and profile publication. Credential-consuming actions require confirmMutation=true plus a reason, always persist recoverable state, and never return a cookie, proof, or token.",
     inputSchema: {
-      action: z.enum(["start", "complete", "mint-from-session"]).optional(),
+      action: z.enum(["start", "complete", "complete-factor", "mint-from-session"]).optional(),
       email: z.string().optional(),
+      factor: z.enum(["totp"]).optional(),
       code: z.string().optional(),
       roomId: z.string().optional(),
       roomHandle: z.string().optional(),

--- a/packages/mcp-server/tool-contract.lock.json
+++ b/packages/mcp-server/tool-contract.lock.json
@@ -167,6 +167,7 @@
       "code",
       "confirmMutation",
       "email",
+      "factor",
       "force",
       "profile",
       "reason",

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.14 (2026-08-07)
+
+- Continue hardened email login through protected pending state and explicit TOTP completion (#84, parle#705).
+
 ## 0.7.13 (2026-08-06)
 
 - Refresh the native shared controller so Pi recovers responsive work after reconnect or total advisory hint loss without requiring later room activity (#80).

--- a/packages/pi-extension/README.md
+++ b/packages/pi-extension/README.md
@@ -59,14 +59,16 @@ PARLE_ROOM_AGENT_TOKEN=...
 ```
 
 For a returning account, use `parle_login` instead of raw `parle_request` calls.
-It sends the email code and completes login by persisting only the human
-session cookie to a `session` file beside the resolved profile catalog
-(`~/.parle/session` by default; one `PARLE_PROFILES_PATH` override relocates
-the whole secrets home). A separate `mint-from-session` call with exact room
-and agent selectors mints a room-bound token and atomically writes the selected
-profile with `0600` permissions. Because both operations handle plaintext
-credentials, they require `confirmMutation: true` plus a nonempty `reason`, and
-`writeCredentials: false` is rejected. `profile`
+It sends the email code and completes login by persisting either the human
+session cookie to a `session` file or, for a hardened account, the opaque
+pending-login cookie to a transient `login` file beside the resolved profile
+catalog. `complete-factor` then spends TOTP and atomically promotes that pending
+state to the human session (`~/.parle/session` by default; one
+`PARLE_PROFILES_PATH` override relocates the whole secrets home). A separate
+`mint-from-session` call with exact room and agent selectors mints a room-bound
+token and atomically writes the selected profile with `0600` permissions.
+Credential-consuming operations require `confirmMutation: true` plus a nonempty
+`reason`, and `writeCredentials: false` is rejected. `profile`
 defaults to `default`. Labels are 1 to 64 characters, start with a letter or
 number, and contain only letters, numbers, dot, underscore, or hyphen. Replacing
 an existing section requires `force: true`; the result includes the prior
@@ -114,7 +116,7 @@ The extension registers these Pi tools:
 - `parle_status` - show redacted config provenance and runtime state.
 - `parle_switch_profile` - atomically switch this live Pi process to another named profile without editing `.env` or persistent configuration.
 - `parle_setup` - diagnose missing configuration.
-- `parle_login` - request and complete email login, persist only the human session, then separately mint and save a named room-bound profile with `mint-from-session`. Complete and mint operations require `confirmMutation: true` plus a reason. Pass `force: true` only when intentionally replacing that profile.
+- `parle_login` - request and complete email login. Unhardened accounts persist the human session immediately; hardened accounts persist opaque pending state and continue through `complete-factor` with TOTP. Then `mint-from-session` separately mints and saves a named room-bound profile. Credential-consuming operations require `confirmMutation: true` plus a reason. Pass `force: true` only when intentionally replacing that profile.
 - `parle_create_room` - create one private or shared room through the fixed human-session endpoint.
 - `parle_add_own_agent_seat` - admit one of the authenticated principal's own durable agents onto a shared room's seat plane.
 - `parle_harden_account` - perform one typed account-hardening transition without accepting a secret or path. The human separately runs `parle-hardening-secret` on a controlling TTY; it is never auto-launched.

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -1673,6 +1673,7 @@ var UUID_RE3 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 var INVITE_SECRET_RE = /^parle_inv_\S{16,256}$/;
 var INVITE_CODE_RE = /^[A-Z0-9]{6,32}$/;
 var SESSION_COOKIE_RE = /^__Host-parle_session=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
+var LOGIN_CHALLENGE_COOKIE_RE = /^__Host-parle_login=[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
 var RESERVED_HANDLES = /* @__PURE__ */ new Set(["admin", "agent", "agents", "api", "me", "null", "parle", "room", "rooms", "root", "support", "system", "www"]);
 var MINT_DENIAL_NEXT_ACTION = {
   unhardened: "set a password, then enroll a second factor",
@@ -1896,6 +1897,9 @@ function validateProfileLabel(raw) {
 function sessionCookieFilePath(catalogPath) {
   return join4(dirname3(catalogPath), "session");
 }
+function pendingLoginCookieFilePath(catalogPath) {
+  return join4(dirname3(catalogPath), "login");
+}
 function assertNoSymlinkPathComponents(path) {
   const absolute = resolve(path);
   const root = parse(absolute).root;
@@ -1949,18 +1953,18 @@ function safeProfileWritePath(path) {
     throw new Error(`Refusing to write Parle profiles because ${path} does not resolve to a file owned by the current user.`);
   return writePath;
 }
-function writeSessionCookieFile(catalogPath, cookie) {
+function writeCookieFile(catalogPath, filename, cookie) {
   const directory = ensureProfileDirectory(catalogPath);
-  const path = sessionCookieFilePath(catalogPath);
+  const path = join4(dirname3(catalogPath), filename);
   const writePath = safeProfileWritePath(join4(directory, basename(path)));
-  const tempPath = join4(dirname3(writePath), `.session.${process.pid}.${Date.now()}.tmp`);
+  const tempPath = join4(dirname3(writePath), `.${filename}.${process.pid}.${Date.now()}.tmp`);
   try {
     writeFileSync2(tempPath, `${cookie}
 `, { mode: 384, flag: "wx" });
     if (process.platform !== "win32")
       chmodSync2(tempPath, 384);
     if (ensureProfileDirectory(catalogPath) !== directory)
-      throw new Error("Parle credential directory changed during session persistence.");
+      throw new Error("Parle credential directory changed during cookie persistence.");
     safeProfileWritePath(writePath);
     renameSync3(tempPath, writePath);
     if (process.platform !== "win32")
@@ -1973,6 +1977,26 @@ function writeSessionCookieFile(catalogPath, cookie) {
     }
   }
   return path;
+}
+function writeSessionCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "session", cookie);
+}
+function writePendingLoginCookieFile(catalogPath, cookie) {
+  return writeCookieFile(catalogPath, "login", cookie);
+}
+function readPendingLoginCookieFile(catalogPath) {
+  const path = safeFile(pendingLoginCookieFilePath(catalogPath), "Parle pending login credential", false);
+  const cookie = readFileSync4(path, "utf8").trim();
+  if (!LOGIN_CHALLENGE_COOKIE_RE.test(cookie))
+    throw new Error("Parle pending login credential is malformed. Remove it and restart email login.");
+  return cookie;
+}
+function removePendingLoginCookieFile(catalogPath) {
+  const path = pendingLoginCookieFilePath(catalogPath);
+  if (!existsSync3(path))
+    return;
+  safeFile(path, "Parle pending login credential", false);
+  unlinkSync2(path);
 }
 function profileSectionRange(text, label) {
   const headers = [];
@@ -2162,15 +2186,20 @@ function chooseInventoryItem(items, idKey, handleKey, label, requestedId, reques
   }
   return items.length === 1 ? items[0] : void 0;
 }
-function extractSessionCookie(headers) {
+function setCookieValues(headers) {
   const getSetCookie = headers.getSetCookie;
-  const values = typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
-  for (const value of values) {
-    const match = value.match(/(?:^|,\s*)(__Host-parle_session=[^;,\s]+)/);
+  return typeof getSetCookie === "function" ? getSetCookie.call(headers) : [headers.get("set-cookie")].filter(Boolean);
+}
+function extractCookie(headers, name) {
+  for (const value of setCookieValues(headers)) {
+    const match = value.match(new RegExp(`(?:^|,\\s*)(${name}=[^;,\\s]+)`));
     if (match)
       return match[1];
   }
   return void 0;
+}
+function clearsCookie(headers, name) {
+  return setCookieValues(headers).some((value) => value.includes(`${name}=`) && /(?:Max-Age=0|Max-Age=-1|Expires=Thu, 01 Jan 1970)/i.test(value));
 }
 var ParleAccountClient = class {
   cwd;
@@ -2306,12 +2335,58 @@ var ParleAccountClient = class {
     const text = scrub(buffer.toString("utf8"), Object.values(body));
     if (!response.ok)
       throw new Error(`Parle email login ${path.endsWith("/start") ? "start" : "complete"} failed ${response.status}: ${truncateText(text, 4096).text}`);
-    return { json: parseJson2(text) || {}, headers: response.headers };
+    return { status: response.status, json: parseJson2(text) || {}, headers: response.headers };
+  }
+  async completeLoginFactor(config, code, signal) {
+    const pendingCookie = readPendingLoginCookieFile(config.catalogPath);
+    const response = await this.fetchImpl(new URL("/v/auth/login/complete", config.apiBase), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "Parle-Version": config.version,
+        Cookie: pendingCookie
+      },
+      body: JSON.stringify({ factor: "totp", code }),
+      signal
+    });
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_RESPONSE_BYTES2)
+      throw new Error(`Parle API response exceeded ${MAX_RESPONSE_BYTES2} bytes.`);
+    const text = scrub(buffer.toString("utf8"), [code, pendingCookie]);
+    if (response.status === 401) {
+      const terminal = clearsCookie(response.headers, "__Host-parle_login");
+      if (terminal)
+        removePendingLoginCookieFile(config.catalogPath);
+      return {
+        status: "factor_rejected",
+        retryable: !terminal,
+        pendingLoginPreserved: !terminal,
+        secrets: "redacted; login challenge and TOTP were not returned in tool output",
+        next: terminal ? "The pending login is no longer usable. Start a new email login." : "The pending login remains usable. Retry complete-factor with the current authenticator code; do not request another email code."
+      };
+    }
+    if (!response.ok)
+      throw new Error(`Parle login factor completion failed ${response.status}: ${truncateText(text, 4096).text}`);
+    if (response.status !== 204)
+      throw new Error(`Parle login factor completion returned unexpected status ${response.status}.`);
+    const sessionCookie = extractCookie(response.headers, "__Host-parle_session");
+    if (!sessionCookie || !SESSION_COOKIE_RE.test(sessionCookie))
+      throw new Error("Parle login factor completion succeeded without a valid human session cookie. Pending state was preserved.");
+    const sessionCookiePath = writeSessionCookieFile(config.catalogPath, sessionCookie);
+    removePendingLoginCookieFile(config.catalogPath);
+    return {
+      status: "session_saved",
+      wroteSessionCookie: true,
+      sessionCookiePath,
+      secrets: "redacted; login challenge, TOTP, and PARLE_SESSION_COOKIE were not returned in tool output",
+      next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+    };
   }
   async login(params, signal) {
     const action = params.action || (params.code ? "complete" : "start");
     if (action !== "start" && (params.confirmMutation !== true || !params.reason?.trim()))
-      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials or minting a token.`);
+      throw new Error(`parle_login ${action} requires confirmMutation=true and a reason before persisting credentials, spending proof attempts, or minting a token.`);
     const config = resolveAccountBaseConfig(this.cwd, this.env, { allowMissingProfile: true });
     const writeCredentials = params.writeCredentials !== false;
     const profileName = params.profile || "default";
@@ -2322,8 +2397,21 @@ var ParleAccountClient = class {
       return {
         status: "code_requested",
         email: params.email,
-        next: "Call parle_login again with the same email and the code. The complete step will capture Set-Cookie and save local credentials without printing secrets."
+        next: "Call parle_login again with the same email and the code. Unhardened accounts save the human session immediately; hardened accounts continue with TOTP without requesting another email code."
       };
+    }
+    if (!writeCredentials) {
+      if (action === "complete")
+        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
+      if (action === "complete-factor")
+        throw new Error("parle_login complete-factor refuses writeCredentials=false because it would spend a TOTP attempt without durable pending-state recovery.");
+      if (action === "mint-from-session")
+        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
+    }
+    if (action === "complete-factor") {
+      if (params.factor !== "totp" || !params.code?.trim())
+        throw new Error("parle_login complete-factor requires factor='totp' and the current authenticator code.");
+      return this.completeLoginFactor(config, params.code.trim(), signal);
     }
     let sessionCookie = config.sessionCookie;
     if (action === "complete") {
@@ -2331,23 +2419,35 @@ var ParleAccountClient = class {
         throw new Error("parle_login complete requires email.");
       if (!params.code)
         throw new Error("parle_login complete requires code.");
-      if (!writeCredentials)
-        throw new Error("parle_login complete refuses writeCredentials=false because it would consume a one-time code without durable credential recovery.");
       const completed = await this.emailRequest(config, "/v/auth/email/complete", { email: params.email, code: params.code }, signal);
-      sessionCookie = extractSessionCookie(completed.headers);
-      if (!sessionCookie)
-        throw new Error("Parle email login completed but no __Host-parle_session Set-Cookie header was present. Credential persistence cannot continue safely.");
-      const sessionCookiePath = writeSessionCookieFile(config.catalogPath, sessionCookie);
+      sessionCookie = extractCookie(completed.headers, "__Host-parle_session");
+      if (completed.status === 201 && sessionCookie && SESSION_COOKIE_RE.test(sessionCookie)) {
+        const sessionCookiePath = writeSessionCookieFile(config.catalogPath, sessionCookie);
+        removePendingLoginCookieFile(config.catalogPath);
+        return {
+          status: "session_saved",
+          wroteSessionCookie: true,
+          sessionCookiePath,
+          secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
+          next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        };
+      }
+      const pendingCookie = extractCookie(completed.headers, "__Host-parle_login");
+      const factors = Array.isArray(completed.json?.factors) ? completed.json.factors.filter((factor) => typeof factor === "string") : [];
+      if (completed.status !== 202 || completed.json?.status !== "factor_required" || !pendingCookie || !LOGIN_CHALLENGE_COOKIE_RE.test(pendingCookie) || !factors.includes("totp") || typeof completed.json?.expires_at !== "string") {
+        throw new Error("Parle email login returned an invalid session-or-factor response. No credential was persisted.");
+      }
+      const pendingLoginCookiePath = writePendingLoginCookieFile(config.catalogPath, pendingCookie);
       return {
-        status: "session_saved",
-        wroteSessionCookie: true,
-        sessionCookiePath,
-        secrets: "redacted; PARLE_SESSION_COOKIE was not returned in tool output",
-        next: "Call parle_login with action:'mint-from-session', an exact room selector, and an exact agent selector to mint and save one room-bound profile."
+        status: "factor_required",
+        factors,
+        expires_at: completed.json.expires_at,
+        wrotePendingLoginCookie: true,
+        pendingLoginCookiePath,
+        secrets: "redacted; login challenge and email code were not returned in tool output",
+        next: "Call parle_login with action:'complete-factor', factor:'totp', and the current authenticator code. Do not request another email code."
       };
     } else if (action === "mint-from-session") {
-      if (!writeCredentials)
-        throw new Error("parle_login mint-from-session refuses writeCredentials=false because it would mint a plaintext token without durable credential recovery.");
       preflightProfileWrite(profileName, params.force === true, config.catalogPath);
       if (!sessionCookie)
         throw new Error(`parle_login mint-from-session requires PARLE_SESSION_COOKIE in env or .env, or a session file at ${sessionCookieFilePath(config.catalogPath)} (written by parle_login complete).`);
@@ -5601,7 +5701,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.13";
+var PI_EXTENSION_VERSION = "0.7.14";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";
@@ -7170,20 +7270,21 @@ function parleExtension(pi) {
   pi.registerTool({
     name: "parle_login",
     label: "Parle Login",
-    description: "First-class Parle email login and local credential bootstrap. Complete persists only the human session cookie to a session file beside the resolved profile catalog. mint-from-session separately mints one room-bound agent token and atomically writes a named 0600 profile (~/.parle/profiles by default, PARLE_PROFILES_PATH to relocate). Both require confirmMutation=true plus a reason. The profile defaults to default. Existing profiles require force=true and replacements return the prior agent_token_id when available. Secrets are never returned in tool output.",
+    description: "First-class Parle email login and local credential bootstrap. Complete persists either the human session or an opaque pending-login cookie beside the resolved profile catalog. For a hardened account, complete-factor spends TOTP and promotes pending state to the human session. mint-from-session separately mints one room-bound agent token and atomically writes a named 0600 profile (~/.parle/profiles by default, PARLE_PROFILES_PATH to relocate). Credential-consuming actions require confirmMutation=true plus a reason. The profile defaults to default. Existing profiles require force=true and replacements return the prior agent_token_id when available. Cookies, proofs, and tokens are never returned in tool output.",
     parameters: Type.Object({
-      action: Type.Optional(Type.Unsafe({ type: "string", enum: ["start", "complete", "mint-from-session"] })),
+      action: Type.Optional(Type.Unsafe({ type: "string", enum: ["start", "complete", "complete-factor", "mint-from-session"] })),
       email: Type.Optional(Type.String()),
+      factor: Type.Optional(Type.Unsafe({ type: "string", enum: ["totp"] })),
       code: Type.Optional(Type.String()),
       roomId: Type.Optional(Type.String({ description: "Room selector. Overrides resolved PARLE_ROOM_ID." })),
       roomHandle: Type.Optional(Type.String({ description: "Room selector. Overrides resolved PARLE_ROOM_HANDLE." })),
       agentId: Type.Optional(Type.String({ description: "Agent selector. Overrides resolved PARLE_AGENT_ID." })),
       agentHandle: Type.Optional(Type.String({ description: "Agent selector. Overrides resolved PARLE_AGENT_HANDLE." })),
-      writeCredentials: Type.Optional(Type.Boolean({ description: "Must remain true so complete persists the session cookie and mint-from-session persists the profile beside the resolved catalog." })),
+      writeCredentials: Type.Optional(Type.Boolean({ description: "Must remain true so complete persists session or pending state, complete-factor persists the human session, and mint-from-session persists the profile beside the resolved catalog." })),
       profile: Type.Optional(Type.String({ description: "Safe local profile label.", default: "default" })),
       force: Type.Optional(Type.Boolean({ description: "Required to replace an existing profile section." })),
-      confirmMutation: Type.Optional(Type.Boolean({ description: "Required true for complete before persisting the session and for mint-from-session before minting and persisting a token." })),
-      reason: Type.Optional(Type.String({ description: "Required explanation for complete and mint-from-session." }))
+      confirmMutation: Type.Optional(Type.Boolean({ description: "Required true for complete before consuming the email code, for complete-factor before spending a TOTP attempt, and for mint-from-session before minting and persisting a token." })),
+      reason: Type.Optional(Type.String({ description: "Required explanation for complete, complete-factor, and mint-from-session." }))
     }),
     async execute(_id, params, signal, _update, ctx) {
       lastCtx = ctx;

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.13";
+const PI_EXTENSION_VERSION = "0.7.14";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.
@@ -2019,20 +2019,21 @@ export default function parleExtension(pi: any) {
   pi.registerTool({
     name: "parle_login",
     label: "Parle Login",
-    description: "First-class Parle email login and local credential bootstrap. Complete persists only the human session cookie to a session file beside the resolved profile catalog. mint-from-session separately mints one room-bound agent token and atomically writes a named 0600 profile (~/.parle/profiles by default, PARLE_PROFILES_PATH to relocate). Both require confirmMutation=true plus a reason. The profile defaults to default. Existing profiles require force=true and replacements return the prior agent_token_id when available. Secrets are never returned in tool output.",
+    description: "First-class Parle email login and local credential bootstrap. Complete persists either the human session or an opaque pending-login cookie beside the resolved profile catalog. For a hardened account, complete-factor spends TOTP and promotes pending state to the human session. mint-from-session separately mints one room-bound agent token and atomically writes a named 0600 profile (~/.parle/profiles by default, PARLE_PROFILES_PATH to relocate). Credential-consuming actions require confirmMutation=true plus a reason. The profile defaults to default. Existing profiles require force=true and replacements return the prior agent_token_id when available. Cookies, proofs, and tokens are never returned in tool output.",
     parameters: Type.Object({
-      action: Type.Optional(Type.Unsafe({ type: "string", enum: ["start", "complete", "mint-from-session"] })),
+      action: Type.Optional(Type.Unsafe({ type: "string", enum: ["start", "complete", "complete-factor", "mint-from-session"] })),
       email: Type.Optional(Type.String()),
+      factor: Type.Optional(Type.Unsafe({ type: "string", enum: ["totp"] })),
       code: Type.Optional(Type.String()),
       roomId: Type.Optional(Type.String({ description: "Room selector. Overrides resolved PARLE_ROOM_ID." })),
       roomHandle: Type.Optional(Type.String({ description: "Room selector. Overrides resolved PARLE_ROOM_HANDLE." })),
       agentId: Type.Optional(Type.String({ description: "Agent selector. Overrides resolved PARLE_AGENT_ID." })),
       agentHandle: Type.Optional(Type.String({ description: "Agent selector. Overrides resolved PARLE_AGENT_HANDLE." })),
-      writeCredentials: Type.Optional(Type.Boolean({ description: "Must remain true so complete persists the session cookie and mint-from-session persists the profile beside the resolved catalog." })),
+      writeCredentials: Type.Optional(Type.Boolean({ description: "Must remain true so complete persists session or pending state, complete-factor persists the human session, and mint-from-session persists the profile beside the resolved catalog." })),
       profile: Type.Optional(Type.String({ description: "Safe local profile label.", default: "default" })),
       force: Type.Optional(Type.Boolean({ description: "Required to replace an existing profile section." })),
-      confirmMutation: Type.Optional(Type.Boolean({ description: "Required true for complete before persisting the session and for mint-from-session before minting and persisting a token." })),
-      reason: Type.Optional(Type.String({ description: "Required explanation for complete and mint-from-session." })),
+      confirmMutation: Type.Optional(Type.Boolean({ description: "Required true for complete before consuming the email code, for complete-factor before spending a TOTP attempt, and for mint-from-session before minting and persisting a token." })),
+      reason: Type.Optional(Type.String({ description: "Required explanation for complete, complete-factor, and mint-from-session." })),
     }),
     async execute(_id, params: ParleLoginParams, signal, _update, ctx) {
       lastCtx = ctx;

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -746,7 +746,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.13" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.14" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1420,7 +1420,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.13");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.14");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- continue hardened email login through the canonical TOTP challenge
- preserve unhardened email login and session persistence
- keep the pending login cookie in protected transient local custody
- expose typed Pi and MCP continuation actions without returning secrets
- refresh package versions, changelogs, manifests, and bundled artifacts

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm check:manifests`
- `pnpm check:mcp-artifacts`
- independent security review: APPROVE

Closes #84
