### PR TITLE
Improve missing saved-start guidance

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.25 (2026-08-11)
+
+- Surface clearer saved-start not-found guidance from the bundled MCP server.
+
 ## 0.8.24 (2026-08-11)
 
 - Refresh the bundled MCP runtime with local saved-start management and live session aliases (#107).

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.24"
+        "PARLE_INTEGRATION_VERSION": "0.8.25"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -35626,8 +35626,10 @@ var SavedStartNotFoundError = class extends SavedStartConfigError {
   selector;
   availableSavedStarts;
   constructor(selector, availableSavedStarts, path) {
-    const available = availableSavedStarts.join(", ") || "none";
-    super(`Parle saved start ${selector} was not found in ${path}. Available saved starts: ${available}`, "saved_start_not_found");
+    const guidance = availableSavedStarts.length ? `Available saved starts:
+${availableSavedStarts.map((name) => `- ${name}`).join("\n")}` : "No saved starts are configured. Create one with /parle save <name>.";
+    super(`Parle saved start ${selector} was not found in ${path}.
+${guidance}`, "saved_start_not_found");
     this.name = "SavedStartNotFoundError";
     this.selector = selector;
     this.availableSavedStarts = availableSavedStarts;
@@ -38825,7 +38827,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.24";
+var MCP_CLIENT_VERSION = "0.7.25";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
       ],
       "env": {
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.26"
+        "PARLE_INTEGRATION_VERSION": "0.9.27"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.27 (2026-08-11)
+
+- Surface clearer saved-start not-found guidance from the bundled MCP server.
+
 ## 0.9.26 (2026-08-11)
 
 - Add saved-start guidance and refresh the MCP bundle with local start management and live session aliases (#107).

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -35626,8 +35626,10 @@ var SavedStartNotFoundError = class extends SavedStartConfigError {
   selector;
   availableSavedStarts;
   constructor(selector, availableSavedStarts, path) {
-    const available = availableSavedStarts.join(", ") || "none";
-    super(`Parle saved start ${selector} was not found in ${path}. Available saved starts: ${available}`, "saved_start_not_found");
+    const guidance = availableSavedStarts.length ? `Available saved starts:
+${availableSavedStarts.map((name) => `- ${name}`).join("\n")}` : "No saved starts are configured. Create one with /parle save <name>.";
+    super(`Parle saved start ${selector} was not found in ${path}.
+${guidance}`, "saved_start_not_found");
     this.name = "SavedStartNotFoundError";
     this.selector = selector;
     this.availableSavedStarts = availableSavedStarts;
@@ -38825,7 +38827,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.24";
+var MCP_CLIENT_VERSION = "0.7.25";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.24 (2026-08-11)
+
+- Render missing saved starts as a readable list and give empty catalogs a direct creation prompt.
+
 ## 0.8.23 (2026-08-11)
 
 - Add a credential-free saved-start catalog with safe list, load, save, and delete primitives for optional profile, alias, and opaque next instructions (#107).

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/agent-client",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/client/src/launches.ts
+++ b/packages/client/src/launches.ts
@@ -34,8 +34,10 @@ export class SavedStartNotFoundError extends SavedStartConfigError {
   readonly availableSavedStarts: string[];
 
   constructor(selector: string, availableSavedStarts: string[], path: string) {
-    const available = availableSavedStarts.join(", ") || "none";
-    super(`Parle saved start ${selector} was not found in ${path}. Available saved starts: ${available}`, "saved_start_not_found");
+    const guidance = availableSavedStarts.length
+      ? `Available saved starts:\n${availableSavedStarts.map((name) => `- ${name}`).join("\n")}`
+      : "No saved starts are configured. Create one with /parle save <name>.";
+    super(`Parle saved start ${selector} was not found in ${path}.\n${guidance}`, "saved_start_not_found");
     this.name = "SavedStartNotFoundError";
     this.selector = selector;
     this.availableSavedStarts = availableSavedStarts;

--- a/packages/client/test/launches.test.mjs
+++ b/packages/client/test/launches.test.mjs
@@ -79,10 +79,20 @@ test("saved starts reject unknown fields, invalid aliases, duplicate names, and 
 test("save, load, list, replace, and delete use one owner-only catalog", () => {
   const { root, path } = fixture();
   try {
+    assert.throws(
+      () => loadSavedStart("missing", path),
+      (error) => error instanceof SavedStartNotFoundError && error.message === `Parle saved start missing was not found in ${path}.\nNo saved starts are configured. Create one with /parle save <name>.`,
+    );
+
     saveSavedStart({ name: "galexc-guru", profile: "galexc-seedwork", alias: "galexc-net-guru", next: "/galexc-guru" }, path);
     saveSavedStart({ name: "issue-collector", profile: "galexc-seedwork", alias: "issue-collector", next: "/issue-collector" }, path);
     assert.equal(statSync(path).mode & 0o777, 0o600);
     assert.deepEqual([...readSavedStarts(path).keys()], ["galexc-guru", "issue-collector"]);
+    assert.throws(
+      () => loadSavedStart("missing", path),
+      (error) => error instanceof SavedStartNotFoundError
+        && error.message === `Parle saved start missing was not found in ${path}.\nAvailable saved starts:\n- galexc-guru\n- issue-collector`,
+    );
     assert.equal(loadSavedStart("galexc-guru", path).next, "/galexc-guru");
 
     saveSavedStart({ name: "galexc-guru", profile: "galexc-seedwork", next: "say hello!" }, path);
@@ -92,7 +102,12 @@ test("save, load, list, replace, and delete use one owner-only catalog", () => {
     assert.equal(deleteSavedStart("galexc-guru", path), true);
     assert.equal(deleteSavedStart("galexc-guru", path), false);
     assert.deepEqual([...readSavedStarts(path).keys()], ["issue-collector"]);
-    assert.throws(() => loadSavedStart("missing", path), (error) => error instanceof SavedStartNotFoundError && error.availableSavedStarts.join(",") === "issue-collector");
+    assert.throws(
+      () => loadSavedStart("missing", path),
+      (error) => error instanceof SavedStartNotFoundError
+        && error.availableSavedStarts.join(",") === "issue-collector"
+        && error.message === `Parle saved start missing was not found in ${path}.\nAvailable saved starts:\n- issue-collector`,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.24"
+        "PARLE_INTEGRATION_VERSION": "0.6.25"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.25 (2026-08-11)
+
+- Surface clearer saved-start not-found guidance from the bundled MCP server.
+
 ## 0.6.24 (2026-08-11)
 
 - Add saved-start guidance and refresh the MCP bundle with local start management and live session aliases (#107).

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -35626,8 +35626,10 @@ var SavedStartNotFoundError = class extends SavedStartConfigError {
   selector;
   availableSavedStarts;
   constructor(selector, availableSavedStarts, path) {
-    const available = availableSavedStarts.join(", ") || "none";
-    super(`Parle saved start ${selector} was not found in ${path}. Available saved starts: ${available}`, "saved_start_not_found");
+    const guidance = availableSavedStarts.length ? `Available saved starts:
+${availableSavedStarts.map((name) => `- ${name}`).join("\n")}` : "No saved starts are configured. Create one with /parle save <name>.";
+    super(`Parle saved start ${selector} was not found in ${path}.
+${guidance}`, "saved_start_not_found");
     this.name = "SavedStartNotFoundError";
     this.selector = selector;
     this.availableSavedStarts = availableSavedStarts;
@@ -38825,7 +38827,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.24";
+var MCP_CLIENT_VERSION = "0.7.25";
 var inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : void 0;
 var MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.4 (2026-08-11)
+
+- Surface clearer saved-start not-found guidance from the shared client.
+
 ## 0.7.3 (2026-08-11)
 
 - Register saved-start and session-alias tools through the native mod and guide ordered opaque next-instruction handling (#107).

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -4633,8 +4633,10 @@ var SavedStartNotFoundError = class extends SavedStartConfigError {
   selector;
   availableSavedStarts;
   constructor(selector, availableSavedStarts, path) {
-    const available = availableSavedStarts.join(", ") || "none";
-    super(`Parle saved start ${selector} was not found in ${path}. Available saved starts: ${available}`, "saved_start_not_found");
+    const guidance = availableSavedStarts.length ? `Available saved starts:
+${availableSavedStarts.map((name) => `- ${name}`).join("\n")}` : "No saved starts are configured. Create one with /parle save <name>.";
+    super(`Parle saved start ${selector} was not found in ${path}.
+${guidance}`, "saved_start_not_found");
     this.name = "SavedStartNotFoundError";
     this.selector = selector;
     this.availableSavedStarts = availableSavedStarts;
@@ -21994,7 +21996,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var ADAPTER_NAME = "@parlehq/command-code-adapter";
-var ADAPTER_VERSION = "0.7.3";
+var ADAPTER_VERSION = "0.7.4";
 var CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 var STATUS_INTERVAL_MS = 5e3;
 var SYSTEM_GUIDANCE = [

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/src/index.ts
+++ b/packages/command-code/src/index.ts
@@ -3,7 +3,7 @@ import { registerParleTools, type DegradedMcpBoot, type ParleMcpClientLike, type
 import { z } from "zod";
 
 const ADAPTER_NAME = "@parlehq/command-code-adapter";
-const ADAPTER_VERSION = "0.7.3";
+const ADAPTER_VERSION = "0.7.4";
 const CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 const STATUS_INTERVAL_MS = 5_000;
 

--- a/packages/command-code/test/index.test.mjs
+++ b/packages/command-code/test/index.test.mjs
@@ -61,7 +61,7 @@ test("root and package manifests expose only the native mod", () => {
   const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
   assert.deepEqual(root.commandcode.mods, ["./packages/command-code/mods/parle.ts"]);
   assert.deepEqual(pkg.commandcode.mods, ["./mods/parle.ts"]);
-  assert.equal(pkg.version, "0.7.3");
+  assert.equal(pkg.version, "0.7.4");
 
   const artifact = readFileSync(resolve("mods/parle.ts"), "utf8");
   assert.match(artifact, /appendCustomMessageEntry/);

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.25 (2026-08-11)
+
+- Surface clearer saved-start not-found guidance from the shared client.
+
 ## 0.7.24 (2026-08-11)
 
 - Add `parle_saved_start` local catalog management and `parle_session_alias` so MCP hosts can execute optional profile, alias, and opaque host-instruction steps without shared role parsing (#107).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.24",
+  "version": "0.7.25",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,7 +12,7 @@ import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, 
 export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.24";
+export const MCP_CLIENT_VERSION = "0.7.25";
 const inheritedWatcherInstance = process.argv[2] === "--parle-watch-request" ? process.env.PARLE_WATCH_CLIENT_INSTANCE_ID : undefined;
 export const MCP_CLIENT_INSTANCE_ID = inheritedWatcherInstance ? assertClientInstanceId(inheritedWatcherInstance) : processClientInstanceId();
 

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.29 (2026-08-11)
+
+- Show missing saved starts one per line and tell users how to create the first one.
+
 ## 0.7.28 (2026-08-11)
 
 - Add `/parle` saved starts with ordered optional profile, alias, and opaque next-instruction handling plus local list, show, save, and delete management (#107).

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -4264,8 +4264,10 @@ var SavedStartNotFoundError = class extends SavedStartConfigError {
   selector;
   availableSavedStarts;
   constructor(selector, availableSavedStarts, path) {
-    const available = availableSavedStarts.join(", ") || "none";
-    super(`Parle saved start ${selector} was not found in ${path}. Available saved starts: ${available}`, "saved_start_not_found");
+    const guidance = availableSavedStarts.length ? `Available saved starts:
+${availableSavedStarts.map((name) => `- ${name}`).join("\n")}` : "No saved starts are configured. Create one with /parle save <name>.";
+    super(`Parle saved start ${selector} was not found in ${path}.
+${guidance}`, "saved_start_not_found");
     this.name = "SavedStartNotFoundError";
     this.selector = selector;
     this.availableSavedStarts = availableSavedStarts;
@@ -6536,7 +6538,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.28";
+var PI_EXTENSION_VERSION = "0.7.29";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.28";
+const PI_EXTENSION_VERSION = "0.7.29";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -796,7 +796,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", participantId: "p-1", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.28" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.29" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1476,7 +1476,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.28");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.29");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- render available saved starts as a vertical list
- tell users how to create their first saved start when the catalog is empty
- update package versions, changelogs, and bundled artifacts

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm check:mcp-artifacts`
- `pnpm check:manifests`
- `git diff --check`