### PR TITLE
Make bare /parle guidance actionable

### DIFF
--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.30 (2026-08-11)
+
+- Make bare `/parle` output task-oriented, with clear commands to run, inspect, create, and remove saved starts.
+
 ## 0.7.29 (2026-08-11)
 
 - Show missing saved starts one per line and tell users how to create the first one.

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -6538,7 +6538,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.29";
+var PI_EXTENSION_VERSION = "0.7.30";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";
@@ -7976,7 +7976,40 @@ function parleExtension(pi) {
         const name = rest.join(" ");
         if (!action || action === "list") {
           const starts2 = [...readSavedStarts(path).values()];
-          const text = starts2.length ? starts2.map((start2) => `${start2.name}${start2.profile ? `  profile=${start2.profile}` : ""}${start2.alias ? `  alias=${start2.alias}` : ""}${start2.next ? "  next=yes" : ""}`).join("\n") : "No saved Parle starts. Use /parle save <name> to create one.";
+          const text = starts2.length ? [
+            "Saved Parle starts:",
+            "",
+            "These reusable shortcuts connect you to a Parle room and can begin a role or instruction.",
+            "",
+            ...starts2.map((start2) => `- ${start2.name}`),
+            "",
+            "Start one:",
+            "  /parle <name>",
+            "",
+            `Example:
+  /parle ${starts2[0].name}`,
+            "",
+            "See details:",
+            "  /parle show <name>",
+            "",
+            "Create another:",
+            "  /parle save <name>",
+            "",
+            "Remove one:",
+            "  /parle delete <name>"
+          ].join("\n") : [
+            "No saved Parle starts yet.",
+            "",
+            "Saved starts are reusable shortcuts that connect you to a Parle room and can begin a role or instruction.",
+            "",
+            "Create your first:",
+            "  /parle save <name>",
+            "",
+            "Example:",
+            "  /parle save issue-collector",
+            "",
+            "Pi will guide you through the rest."
+          ].join("\n");
           ctx.ui.notify(text, "info");
           return;
         }

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.29";
+const PI_EXTENSION_VERSION = "0.7.30";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.
@@ -1872,8 +1872,40 @@ export default function parleExtension(pi: any) {
         if (!action || action === "list") {
           const starts = [...readSavedStarts(path).values()];
           const text = starts.length
-            ? starts.map((start) => `${start.name}${start.profile ? `  profile=${start.profile}` : ""}${start.alias ? `  alias=${start.alias}` : ""}${start.next ? "  next=yes" : ""}`).join("\n")
-            : "No saved Parle starts. Use /parle save <name> to create one.";
+            ? [
+                "Saved Parle starts:",
+                "",
+                "These reusable shortcuts connect you to a Parle room and can begin a role or instruction.",
+                "",
+                ...starts.map((start) => `- ${start.name}`),
+                "",
+                "Start one:",
+                "  /parle <name>",
+                "",
+                `Example:\n  /parle ${starts[0].name}`,
+                "",
+                "See details:",
+                "  /parle show <name>",
+                "",
+                "Create another:",
+                "  /parle save <name>",
+                "",
+                "Remove one:",
+                "  /parle delete <name>",
+              ].join("\n")
+            : [
+                "No saved Parle starts yet.",
+                "",
+                "Saved starts are reusable shortcuts that connect you to a Parle room and can begin a role or instruction.",
+                "",
+                "Create your first:",
+                "  /parle save <name>",
+                "",
+                "Example:",
+                "  /parle save issue-collector",
+                "",
+                "Pi will guide you through the rest.",
+              ].join("\n");
           ctx.ui.notify(text, "info");
           return;
         }

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -141,6 +141,71 @@ test("status resolves explicit and default profiles with shared atomic-mode sema
   assert.equal(defaultStatus.details.roomId.source, "profile:default");
 });
 
+test("/parle lists saved starts with clear next steps", async () => {
+  const cwd = tempProject("PARLE_WATCH_ENABLED=0\n");
+  const catalogDir = join(process.env.HOME, ".parle");
+  mkdirSync(catalogDir, { recursive: true, mode: 0o700 });
+  writeFileSync(join(catalogDir, "launches"), "[galexc-net-guru]\nprofile = galexc-dev\nalias = galexc-net-guru\nnext = share expertise\n\n[issue-collector]\nprofile = galexc-intercom\nalias = issue-collector\nnext = /issue-collector\n", { mode: 0o600 });
+  const harness = installHarness(cwd);
+  const notifications = [];
+  harness.ctx.ui.notify = (message, type) => notifications.push({ message, type });
+
+  await harness.commands.parle.handler("", harness.ctx);
+
+  assert.deepEqual(notifications, [{
+    type: "info",
+    message: [
+      "Saved Parle starts:",
+      "",
+      "These reusable shortcuts connect you to a Parle room and can begin a role or instruction.",
+      "",
+      "- galexc-net-guru",
+      "- issue-collector",
+      "",
+      "Start one:",
+      "  /parle <name>",
+      "",
+      "Example:",
+      "  /parle galexc-net-guru",
+      "",
+      "See details:",
+      "  /parle show <name>",
+      "",
+      "Create another:",
+      "  /parle save <name>",
+      "",
+      "Remove one:",
+      "  /parle delete <name>",
+    ].join("\n"),
+  }]);
+});
+
+test("/parle explains how to create the first saved start", async () => {
+  const cwd = tempProject("PARLE_WATCH_ENABLED=0\n");
+  const harness = installHarness(cwd);
+  const notifications = [];
+  harness.ctx.ui.notify = (message, type) => notifications.push({ message, type });
+
+  await harness.commands.parle.handler("list", harness.ctx);
+
+  assert.deepEqual(notifications, [{
+    type: "info",
+    message: [
+      "No saved Parle starts yet.",
+      "",
+      "Saved starts are reusable shortcuts that connect you to a Parle room and can begin a role or instruction.",
+      "",
+      "Create your first:",
+      "  /parle save <name>",
+      "",
+      "Example:",
+      "  /parle save issue-collector",
+      "",
+      "Pi will guide you through the rest.",
+    ].join("\n"),
+  }]);
+});
+
 test("/parle sends an opaque next instruction through Pi without posting to Parle", async () => {
   const cwd = tempProject("PARLE_WATCH_ENABLED=0\n");
   const catalogDir = join(process.env.HOME, ".parle");
@@ -796,7 +861,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", participantId: "p-1", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.29" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.30" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1476,7 +1541,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.29");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.30");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- explain what saved starts are in plain language
- list saved-start names without exposing configuration jargon
- show how to start, inspect, create, and remove saved starts
- guide empty catalogs through creating the first saved start

## Validation

- `pnpm --filter @parlehq/pi-extension test`
- `pnpm typecheck`
- `pnpm check:mcp-artifacts`
- `pnpm check:manifests`
- `git diff --check`