### PR TITLE
Fix plain status delivery evidence clobber

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.40 (2026-08-17)
+
+- Refresh the bundled MCP runtime so plain status preserves healthy responsive-delivery evidence (#120).
+
 ## 0.8.39 (2026-08-17)
 
 - Refresh the bundled account client with honest conditional email login start guidance.

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.39",
+  "version": "0.8.40",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.39"
+        "PARLE_INTEGRATION_VERSION": "0.8.40"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.39",
+  "version": "0.8.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -38264,6 +38264,7 @@ var HookDeliveryBridge = class {
     this.removeOwnRuntimeArtifacts();
   }
   async startBridge() {
+    if (this.server?.listening && this.controller.status().running) return;
     this.lastError = void 0;
     this.publishEvidence("starting", { expectedProgressMs: 12e4 });
     if (!this.unsubscribeCommitGuard) {
@@ -39148,7 +39149,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.39";
+var MCP_CLIENT_VERSION = "0.7.40";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -9,7 +9,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.43"
+        "PARLE_INTEGRATION_VERSION": "0.9.44"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.44 (2026-08-17)
+
+- Preserve healthy hook-bridge `watching` evidence across plain status calls (#120).
+
 ## 0.9.43 (2026-08-17)
 
 - Refresh the bundled account client with honest conditional email login start guidance.

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -38264,6 +38264,7 @@ var HookDeliveryBridge = class {
     this.removeOwnRuntimeArtifacts();
   }
   async startBridge() {
+    if (this.server?.listening && this.controller.status().running) return;
     this.lastError = void 0;
     this.publishEvidence("starting", { expectedProgressMs: 12e4 });
     if (!this.unsubscribeCommitGuard) {
@@ -39148,7 +39149,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.39";
+var MCP_CLIENT_VERSION = "0.7.40";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.39",
+  "version": "0.6.40",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.39"
+        "PARLE_INTEGRATION_VERSION": "0.6.40"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.40 (2026-08-17)
+
+- Refresh the bundled MCP runtime so plain status preserves healthy responsive-delivery evidence (#120).
+
 ## 0.6.39 (2026-08-17)
 
 - Refresh the bundled account client with honest conditional email login start guidance.

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -38264,6 +38264,7 @@ var HookDeliveryBridge = class {
     this.removeOwnRuntimeArtifacts();
   }
   async startBridge() {
+    if (this.server?.listening && this.controller.status().running) return;
     this.lastError = void 0;
     this.publishEvidence("starting", { expectedProgressMs: 12e4 });
     if (!this.unsubscribeCommitGuard) {
@@ -39148,7 +39149,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.39";
+var MCP_CLIENT_VERSION = "0.7.40";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.39",
+  "version": "0.6.40",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.19 (2026-08-17)
+
+- Refresh the bundled MCP runtime so plain status preserves healthy responsive-delivery evidence (#120).
+
 ## 0.7.18 (2026-08-17)
 
 - Present email login starts as privacy-flat accepted requests, preserve the server status as data, and distinguish returning login from first-time onboarding.

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -22249,7 +22249,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var ADAPTER_NAME = "@parlehq/command-code-adapter";
-var ADAPTER_VERSION = "0.7.18";
+var ADAPTER_VERSION = "0.7.19";
 var CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 var STATUS_INTERVAL_MS = 5e3;
 var SYSTEM_GUIDANCE = [

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/src/index.ts
+++ b/packages/command-code/src/index.ts
@@ -3,7 +3,7 @@ import { registerParleTools, type DegradedMcpBoot, type ParleMcpClientLike, type
 import { z } from "zod";
 
 const ADAPTER_NAME = "@parlehq/command-code-adapter";
-const ADAPTER_VERSION = "0.7.18";
+const ADAPTER_VERSION = "0.7.19";
 const CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 const STATUS_INTERVAL_MS = 5_000;
 

--- a/packages/command-code/test/index.test.mjs
+++ b/packages/command-code/test/index.test.mjs
@@ -61,7 +61,7 @@ test("root and package manifests expose only the native mod", () => {
   const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
   assert.deepEqual(root.commandcode.mods, ["./packages/command-code/mods/parle.ts"]);
   assert.deepEqual(pkg.commandcode.mods, ["./mods/parle.ts"]);
-  assert.equal(pkg.version, "0.7.18");
+  assert.equal(pkg.version, "0.7.19");
   assert.match(readFileSync(resolve("src/index.ts"), "utf8"), new RegExp(`ADAPTER_VERSION = "${pkg.version}"`));
 
   const artifact = readFileSync(resolve("mods/parle.ts"), "utf8");

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.40 (2026-08-17)
+
+- Keep repeated hook-bridge startup from replacing healthy persisted `watching` evidence with `starting`, restoring truthful plain `parle_status` results (#120).
+
 ## 0.7.39 (2026-08-17)
 
 - Expose honest conditional returning-account login start results and stop presenting accepted requests as proof that a code was sent.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/hook-delivery-bridge.ts
+++ b/packages/mcp-server/src/hook-delivery-bridge.ts
@@ -201,6 +201,7 @@ export class HookDeliveryBridge {
   }
 
   private async startBridge(): Promise<void> {
+    if (this.server?.listening && this.controller.status().running) return;
     this.lastError = undefined;
     this.publishEvidence("starting", { expectedProgressMs: 120_000 });
     if (!this.unsubscribeCommitGuard) {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,7 +12,7 @@ import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, 
 export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.39";
+export const MCP_CLIENT_VERSION = "0.7.40";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {

--- a/packages/mcp-server/test/hook-delivery-bridge.test.mjs
+++ b/packages/mcp-server/test/hook-delivery-bridge.test.mjs
@@ -582,6 +582,10 @@ test("hook delivery bridge renews lifecycle evidence on observed progress and to
     await eventually(() => existsSync(evidencePath));
     const opened = JSON.parse(readFileSync(evidencePath, "utf8"));
     assert.equal(opened.state, "watching");
+    void bridge.start();
+    const afterStatus = JSON.parse(readFileSync(evidencePath, "utf8"));
+    assert.equal(afterStatus.state, "watching", "plain status startup must not clobber healthy evidence");
+    assert.equal(afterStatus.updatedAt, opened.updatedAt, "plain status startup must not replace healthy evidence");
     const firstUpdatedAt = opened.updatedAt;
     await settle(5);
     wakeSink.push({ room_id: ROOM });

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.44 (2026-08-17)
+
+- Refresh the bundled MCP runtime so plain status preserves healthy responsive-delivery evidence (#120).
+
 ## 0.7.43 (2026-08-17)
 
 - Present email login starts as privacy-flat accepted requests, preserve the server status as data, and distinguish returning login from first-time onboarding.

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -6737,7 +6737,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.43";
+var PI_EXTENSION_VERSION = "0.7.44";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.43";
+const PI_EXTENSION_VERSION = "0.7.44";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -925,7 +925,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", participantId: "p-1", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.43" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.44" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1611,7 +1611,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.43");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.44");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- keep repeated hook-bridge startup as a true no-op while its listener and responsive controller are healthy
- preserve persisted `watching` evidence and its original progress timestamp across plain `parle_status` calls
- refresh all tracked MCP artifacts and package versions

Closes #120

## Validation

- `pnpm refresh:mcp-artifacts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm check:manifests`
- `pnpm check:mcp-artifacts`
- `git diff --check`