### PR TITLE
Fix native adapter release claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -53,6 +55,9 @@ jobs:
 
       - name: Check manifest versions
         run: pnpm check:manifests
+
+      - name: Check native adapter release claims
+        run: pnpm check:release-claims -- HEAD^
 
       - name: Check clean MCP artifact reproducibility
         run: pnpm check:mcp-artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This repository is the public home for Parle agent harness adapters.
 - `packages/codex-plugin` - Codex plugin wrapping the bundled MCP server artifact and focused Agent Skill guidance.
 - `packages/claude-desktop-extension` - Claude Desktop MCPB package wrapping the same bundled MCP server artifact.
 
-After shared client or MCP server changes, run `pnpm refresh:mcp-artifacts` to rebuild canonical source in dependency order, refresh the native Pi and Command Code bundles, and refresh the three tracked MCP wrappers. Run `pnpm check:mcp-artifacts` before committing to verify clean-checkout reproducibility, stale-dist isolation, and divergence detection. Apply the package version and changelog policy below to every installable package whose bundled runtime changed.
+After shared client or MCP server changes, run `pnpm refresh:mcp-artifacts` to rebuild canonical source in dependency order, refresh the native Pi and Command Code bundles, and refresh the three tracked MCP wrappers. Run `pnpm check:mcp-artifacts` before committing to verify clean-checkout reproducibility, stale-dist isolation, and divergence detection. Run `pnpm check:release-claims` before committing changelog entries for Pi or Command Code; it rejects runtime claims when that adapter's version-normalized bundle has no behavior-bearing change. This is a floor, so review must still verify that each claim matches the changed bytes. Apply the package version and changelog policy below to every installable package whose bundled runtime changed.
 
 ## Tooling
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:mcp": "pnpm --filter @parlehq/mcp-server... build",
     "refresh:mcp-artifacts": "pnpm build:mcp && node scripts/copy-responsive-delivery-reader.mjs && pnpm -F @parlehq/pi-extension build && pnpm -F @parlehq/claude-plugin build && pnpm -F @parlehq/claude-desktop-extension build && pnpm -F @parlehq/command-code-adapter build && pnpm -F @parlehq/codex-plugin build",
     "check:mcp-artifacts": "node scripts/check-reproducible-mcp-artifacts.mjs",
+    "check:release-claims": "node scripts/check-release-claims.mjs",
     "pack:desktop": "pnpm build:mcp && pnpm -F @parlehq/claude-desktop-extension pack:mcpb",
     "check:manifests": "node scripts/check-manifest-versions.mjs",
     "typecheck": "pnpm -r typecheck",

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.19 (2026-08-17)
 
-- Refresh the bundled MCP runtime so plain status preserves healthy responsive-delivery evidence (#120).
+- Release alignment for #120; no Command Code runtime behavior changed because its native delivery path does not use Claude's hook bridge.
 
 ## 0.7.18 (2026-08-17)
 
@@ -10,7 +10,7 @@
 
 ## 0.7.17 (2026-08-16)
 
-- Refresh the bundled MCP runtime with opt-in direct-parent hook-bridge correlation for Claude (#118).
+- Release alignment for #118; no Command Code runtime behavior changed because its native delivery path does not use Claude's hook bridge.
 
 ## 0.7.16 (2026-08-15)
 

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.44 (2026-08-17)
 
-- Refresh the bundled MCP runtime so plain status preserves healthy responsive-delivery evidence (#120).
+- Release alignment for #120; no Pi runtime behavior changed because Pi does not carry the MCP hook bridge.
 
 ## 0.7.43 (2026-08-17)
 
@@ -10,7 +10,7 @@
 
 ## 0.7.42 (2026-08-16)
 
-- Refresh the bundled MCP runtime with opt-in direct-parent hook-bridge correlation for Claude (#118).
+- Release alignment for #118; no Pi runtime behavior changed because Pi does not carry Claude's MCP hook bridge.
 
 ## 0.7.41 (2026-08-15)
 
@@ -18,7 +18,7 @@
 
 ## 0.7.40 (2026-08-14)
 
-- Refresh the shared responsive-delivery resolver so wake-only helpers do not create false owner conflicts.
+- Release alignment only; no Pi runtime behavior changed because the shared resolver update was not present in Pi's bundle.
 
 ## 0.7.39 (2026-08-14)
 

--- a/scripts/check-release-claims.mjs
+++ b/scripts/check-release-claims.mjs
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const base = process.argv[2] || "HEAD";
+const packages = [
+  {
+    name: "Pi extension",
+    changelog: "packages/pi-extension/CHANGELOG.md",
+    artifact: "packages/pi-extension/dist/index.js",
+    normalize: (text) => text.replace(/PI_EXTENSION_VERSION = "[^"]+"/g, 'PI_EXTENSION_VERSION = "<version>"'),
+  },
+  {
+    name: "Command Code",
+    changelog: "packages/command-code/CHANGELOG.md",
+    artifact: "packages/command-code/mods/parle.ts",
+    normalize: (text) => text.replace(/ADAPTER_VERSION = "[^"]+"/g, 'ADAPTER_VERSION = "<version>"'),
+  },
+];
+
+function git(args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
+}
+
+function addedClaims(changelog) {
+  return git(["diff", "--unified=0", "--no-ext-diff", base, "--", changelog])
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1).trim())
+    .filter((line) => line.startsWith("-"));
+}
+
+function claimsRuntimeChange(line) {
+  return !/\b(?:no [^.]*runtime behavior changed|runtime behavior is unchanged)\b/i.test(line);
+}
+
+const failures = [];
+for (const pkg of packages) {
+  const claims = addedClaims(pkg.changelog);
+  if (claims.length === 0) continue;
+
+  const positiveClaims = claims.filter(claimsRuntimeChange);
+  if (positiveClaims.length === 0) continue;
+  // This is a floor, not semantic proof: reviewers still verify that prose
+  // describes the behavior-bearing bytes that changed.
+  const before = pkg.normalize(git(["show", `${base}:${pkg.artifact}`]));
+  const after = pkg.normalize(readFileSync(resolve(root, pkg.artifact), "utf8"));
+  if (before === after) {
+    failures.push(`${pkg.name} claims runtime behavior changed, but ${pkg.artifact} changed only by version or not at all: ${positiveClaims.join(" | ")}`);
+  }
+}
+
+if (failures.length > 0) throw new Error(failures.join("\n"));
+console.log(`Native adapter release claims match carried artifact changes since ${base}.`);


### PR DESCRIPTION
## Summary

- correct five native-adapter changelog entries that claimed behavior absent from their shipped bundles
- add a version-normalized artifact floor for new Pi and Command Code changelog claims
- run the release-claim check in CI and document its review ceiling

## Validation

- `pnpm check:release-claims`
- transient artifact-free claim without runtime keywords rejected
- `pnpm check:manifests`
- `pnpm test`
- `pnpm typecheck`
- `pnpm check:mcp-artifacts`
- `pnpm build`
- `git diff --check`

Closes #135
