### PR TITLE
Preserve Command Code delivery evidence on status

### DIFF
--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.20 (2026-08-17)
+
+- Preserve persisted responsive-delivery success and backoff evidence when repeated status calls find the native controller already running (#136).
+
 ## 0.7.19 (2026-08-17)
 
 - Release alignment for #120; no Command Code runtime behavior changed because its native delivery path does not use Claude's hook bridge.

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -22249,7 +22249,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var ADAPTER_NAME = "@parlehq/command-code-adapter";
-var ADAPTER_VERSION = "0.7.19";
+var ADAPTER_VERSION = "0.7.20";
 var CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 var STATUS_INTERVAL_MS = 5e3;
 var SYSTEM_GUIDANCE = [
@@ -22357,6 +22357,7 @@ var NativeResponsiveDelivery = class {
   }
   async start() {
     if (this.startPromise) return this.startPromise;
+    if (!this.stopped && this.controller.status().running) return;
     this.startPromise = this.startDelivery();
     try {
       await this.startPromise;

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/src/index.ts
+++ b/packages/command-code/src/index.ts
@@ -3,7 +3,7 @@ import { registerParleTools, type DegradedMcpBoot, type ParleMcpClientLike, type
 import { z } from "zod";
 
 const ADAPTER_NAME = "@parlehq/command-code-adapter";
-const ADAPTER_VERSION = "0.7.19";
+const ADAPTER_VERSION = "0.7.20";
 const CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 const STATUS_INTERVAL_MS = 5_000;
 
@@ -127,6 +127,7 @@ export class NativeResponsiveDelivery {
 
   async start(): Promise<void> {
     if (this.startPromise) return this.startPromise;
+    if (!this.stopped && this.controller.status().running) return;
     this.startPromise = this.startDelivery();
     try {
       await this.startPromise;

--- a/packages/command-code/test/index.test.mjs
+++ b/packages/command-code/test/index.test.mjs
@@ -61,7 +61,7 @@ test("root and package manifests expose only the native mod", () => {
   const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
   assert.deepEqual(root.commandcode.mods, ["./packages/command-code/mods/parle.ts"]);
   assert.deepEqual(pkg.commandcode.mods, ["./mods/parle.ts"]);
-  assert.equal(pkg.version, "0.7.19");
+  assert.equal(pkg.version, "0.7.20");
   assert.match(readFileSync(resolve("src/index.ts"), "utf8"), new RegExp(`ADAPTER_VERSION = "${pkg.version}"`));
 
   const artifact = readFileSync(resolve("mods/parle.ts"), "utf8");
@@ -176,6 +176,40 @@ test("session replacement retains deferred work for the replacement turn", async
   const replacement = delivery.foldPending({ messages: [] });
   assert.deepEqual(replacement.messages, [projected]);
   assert.equal(delivery.status().pending, 1);
+});
+
+test("repeated start preserves persisted success and backoff evidence", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "parle-command-code-evidence-"));
+  try {
+    const client = { runtime: { agentSessionId: "agent-1" }, clientInstanceId: "test-client", async ensureReadySafe() {} };
+    const delivery = new source.NativeResponsiveDelivery({ cwd, session: { appendCustomMessageEntry() {} } }, client, () => {});
+    let running = false;
+    delivery.controller.status = () => ({ running });
+    delivery.controller.start = async () => { running = true; };
+
+    await delivery.start();
+    const evidencePath = join(cwd, ".parle", "runtime", "responsive", `${process.pid}.json`);
+    const watching = readFileSync(evidencePath, "utf8");
+    const watchingSnapshot = JSON.parse(watching);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await delivery.start();
+    const watchingAfterStatus = readFileSync(evidencePath, "utf8");
+    assert.equal(watchingAfterStatus, watching, "plain status startup preserves persisted watching evidence byte-for-byte");
+    assert.equal(JSON.parse(watchingAfterStatus).updatedAt, watchingSnapshot.updatedAt);
+    assert.equal(JSON.parse(watchingAfterStatus).lastSuccessAt, watchingSnapshot.lastSuccessAt);
+
+    delivery.handleWakeError(new Error("stream ended unexpectedly"));
+    const backoff = readFileSync(evidencePath, "utf8");
+    const backoffSnapshot = JSON.parse(backoff);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await delivery.start();
+    const backoffAfterStatus = readFileSync(evidencePath, "utf8");
+    assert.equal(backoffAfterStatus, backoff, "plain status startup preserves persisted backoff evidence byte-for-byte");
+    assert.equal(JSON.parse(backoffAfterStatus).updatedAt, backoffSnapshot.updatedAt);
+    assert.equal(JSON.parse(backoffAfterStatus).lastSuccessAt, backoffSnapshot.lastSuccessAt);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("a successful wake reopen clears stale error state and reports watching evidence", () => {


### PR DESCRIPTION
## Summary

- make native responsive-delivery startup a no-op when its controller is already running
- preserve persisted watching and backoff evidence across repeated plain status calls
- version Command Code as `0.7.20` and rebuild the tracked native mod

## Validation

- `pnpm -F @parlehq/command-code-adapter test`
- focused persisted-recorder regression verifies byte-identical watching and backoff files, including `updatedAt` and `lastSuccessAt`
- `pnpm check:release-claims`
- `pnpm check:manifests`
- `pnpm typecheck`
- `pnpm check:mcp-artifacts`
- `pnpm test`
- `pnpm build`
- `git diff --check`

Closes #136
