### PR TITLE
fix(release): republish merged adapters under unique versions

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.42 (2026-08-17)
+
+- Republish the merged #132 and #140 Desktop bundle under a unique version after the concurrent releases shared 0.8.41; runtime behavior is unchanged from main.
+
 ## 0.8.41 (2026-08-17)
 
 - Refresh the bundled MCP runtime so hook-bridge socket startup failures report terminal delivery evidence instead of armed delivery (#132).

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.41"
+        "PARLE_INTEGRATION_VERSION": "0.8.42"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -39256,7 +39256,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.41";
+var MCP_CLIENT_VERSION = "0.7.42";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -9,7 +9,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.45"
+        "PARLE_INTEGRATION_VERSION": "0.9.46"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.46 (2026-08-17)
+
+- Republish the merged #132 and #140 Claude bundle under a unique version after the concurrent releases shared 0.9.45; runtime behavior is unchanged from main.
+
 ## 0.9.45 (2026-08-17)
 
 - Report hook-bridge socket startup failures as terminal instead of claiming responsive delivery is armed (#132).

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -39256,7 +39256,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.41";
+var MCP_CLIENT_VERSION = "0.7.42";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.38 (2026-08-17)
+
+- Republish the merged #132 and #140 client under a unique version after the concurrent releases shared 0.8.37; runtime behavior is unchanged from main.
+
 ## 0.8.37 (2026-08-17)
 
 - Add compact delivery guidance that distinguishes in-progress startup from a hook-bridge socket failure requiring host repair (#132).

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/agent-client",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.41",
+  "version": "0.6.42",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.41"
+        "PARLE_INTEGRATION_VERSION": "0.6.42"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.42 (2026-08-17)
+
+- Republish the merged #132 and #140 Codex bundle under a unique version after the concurrent releases shared 0.6.41; runtime behavior is unchanged from main.
+
 ## 0.6.41 (2026-08-17)
 
 - Refresh the bundled MCP runtime so hook-bridge socket startup failures report terminal delivery evidence instead of armed delivery (#132).

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -39256,7 +39256,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.41";
+var MCP_CLIENT_VERSION = "0.7.42";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.41",
+  "version": "0.6.42",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.22 (2026-08-17)
+
+- Republish the merged #132 and #140 Command Code bundle under a unique version after the concurrent releases shared 0.7.21; runtime behavior is unchanged from main.
+
 ## 0.7.21 (2026-08-17)
 
 - Release alignment for #132; no Command Code runtime behavior changed because its native delivery path does not use the MCP hook bridge.

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -22346,7 +22346,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var ADAPTER_NAME = "@parlehq/command-code-adapter";
-var ADAPTER_VERSION = "0.7.21";
+var ADAPTER_VERSION = "0.7.22";
 var CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 var STATUS_INTERVAL_MS = 5e3;
 var SYSTEM_GUIDANCE = [

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/src/index.ts
+++ b/packages/command-code/src/index.ts
@@ -3,7 +3,7 @@ import { registerParleTools, type DegradedMcpBoot, type ParleMcpClientLike, type
 import { z } from "zod";
 
 const ADAPTER_NAME = "@parlehq/command-code-adapter";
-const ADAPTER_VERSION = "0.7.21";
+const ADAPTER_VERSION = "0.7.22";
 const CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 const STATUS_INTERVAL_MS = 5_000;
 

--- a/packages/command-code/test/index.test.mjs
+++ b/packages/command-code/test/index.test.mjs
@@ -61,7 +61,7 @@ test("root and package manifests expose only the native mod", () => {
   const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
   assert.deepEqual(root.commandcode.mods, ["./packages/command-code/mods/parle.ts"]);
   assert.deepEqual(pkg.commandcode.mods, ["./mods/parle.ts"]);
-  assert.equal(pkg.version, "0.7.21");
+  assert.equal(pkg.version, "0.7.22");
   assert.match(readFileSync(resolve("src/index.ts"), "utf8"), new RegExp(`ADAPTER_VERSION = "${pkg.version}"`));
 
   const artifact = readFileSync(resolve("mods/parle.ts"), "utf8");

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.42 (2026-08-17)
+
+- Republish the merged #132 and #140 MCP runtime under a unique version after the concurrent releases shared 0.7.41; runtime behavior is unchanged from main.
+
 ## 0.7.41 (2026-08-17)
 
 - Publish terminal evidence when hook-bridge socket startup fails and prevent status or connect cards from reporting an unbound bridge as armed (#132).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,7 +12,7 @@ import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, 
 export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.41";
+export const MCP_CLIENT_VERSION = "0.7.42";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.46 (2026-08-17)
+
+- Republish the merged #132 and #140 Pi bundle under a unique version after the concurrent releases shared 0.7.45; runtime behavior is unchanged from main.
+
 ## 0.7.45 (2026-08-17)
 
 - Release alignment for #132; no Pi runtime behavior changed because Pi does not carry the MCP hook bridge.

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -6788,7 +6788,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.45";
+var PI_EXTENSION_VERSION = "0.7.46";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.45",
+  "version": "0.7.46",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.45";
+const PI_EXTENSION_VERSION = "0.7.46";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -925,7 +925,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", participantId: "p-1", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.45" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.46" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1611,7 +1611,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.45");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.46");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- assign unique versions to the merged #132 and #140 adapter artifacts
- refresh every tracked native and MCP bundle so Git marketplace installs can select the corrected content
- document that this is a publication correction with no runtime behavior change from current main

The concurrent #140 and #132 changes previously shared the same package versions. Claude therefore reloaded the earlier published `0.9.45` artifact, which did not contain #132, while the repository carried different bytes under that same version.

## New versions

- client `0.8.38`
- MCP server `0.7.42`
- Pi extension `0.7.46`
- Command Code `0.7.22`
- Claude plugin `0.9.46`
- Codex plugin `0.6.42`
- Claude Desktop extension `0.8.42`

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:manifests`
- `pnpm check:release-claims`
- `pnpm check:mcp-artifacts`
- `git diff --check`

Follow-up for #132.
