### PR TITLE
Advance adapters to Parle-Version 2026-08-17

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.43 (2026-08-17)
+
+- Bundle the 2026-08-17 wire version required by the canonical error-contract hard cut (parlehq/parle#810).
+
 ## 0.8.42 (2026-08-17)
 
 - Republish the merged #132 and #140 Desktop bundle under a unique version after the concurrent releases shared 0.8.41; runtime behavior is unchanged from main.

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.42"
+        "PARLE_INTEGRATION_VERSION": "0.8.43"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -31575,7 +31575,7 @@ function parseErrorEnvelope(value) {
 }
 
 // ../client/dist/protocol.js
-var DEFAULT_VERSION = "2026-08-10";
+var DEFAULT_VERSION = "2026-08-17";
 var ParleApiError = class extends Error {
   status;
   code;
@@ -39256,7 +39256,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.42";
+var MCP_CLIENT_VERSION = "0.7.43";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -9,7 +9,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.46"
+        "PARLE_INTEGRATION_VERSION": "0.9.47"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.47 (2026-08-17)
+
+- Bundle the 2026-08-17 wire version required by the canonical error-contract hard cut (parlehq/parle#810).
+
 ## 0.9.46 (2026-08-17)
 
 - Republish the merged #132 and #140 Claude bundle under a unique version after the concurrent releases shared 0.9.45; runtime behavior is unchanged from main.

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -31575,7 +31575,7 @@ function parseErrorEnvelope(value) {
 }
 
 // ../client/dist/protocol.js
-var DEFAULT_VERSION = "2026-08-10";
+var DEFAULT_VERSION = "2026-08-17";
 var ParleApiError = class extends Error {
   status;
   code;
@@ -39256,7 +39256,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.42";
+var MCP_CLIENT_VERSION = "0.7.43";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.39 (2026-08-17)
+
+- Advance the sole supported Parle-Version to 2026-08-17 for the canonical error-contract hard cut (parlehq/parle#810).
+
 ## 0.8.38 (2026-08-17)
 
 - Republish the merged #132 and #140 client under a unique version after the concurrent releases shared 0.8.37; runtime behavior is unchanged from main.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -25,7 +25,7 @@ Adapters own host-specific registration, schemas, lifecycle hooks, UI text, and 
 
 ## Session lifecycle
 
-The release is pinned to `Parle-Version: 2026-08-10`. Session creation always sends `{}`. When `PARLE_SESSION_ALIAS` is configured, the client creates an anonymous candidate, enters the configured room, verifies candidate wake readiness, reads the durable alias generation through the core alias lookup, and submits one exact generation-fenced claim. A failed claim is never replayed. Recovery prepares a fresh candidate and re-reads the durable fence, including after the prior owner expires.
+The release is pinned to `Parle-Version: 2026-08-17`. Session creation always sends `{}`. When `PARLE_SESSION_ALIAS` is configured, the client creates an anonymous candidate, enters the configured room, verifies candidate wake readiness, reads the durable alias generation through the core alias lookup, and submits one exact generation-fenced claim. A failed claim is never replayed. Recovery prepares a fresh candidate and re-reads the durable fence, including after the prior owner expires.
 
 The client schedules proactive replacement at `max(created_at, expires_at - 5 minutes - jitter)`, where deterministic jitter is below 60 seconds and derived from `agent_session_id`. Timers are injectable, single-flight, bounded after failures, and unreferenced under Node. Session revision events let bridges restart owned wake streams after a committed swap.
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/agent-client",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/client/src/protocol.ts
+++ b/packages/client/src/protocol.ts
@@ -1,5 +1,5 @@
 import type { ErrorAction, ErrorScope } from "./error-envelope.js";
-export const DEFAULT_VERSION = "2026-08-10";
+export const DEFAULT_VERSION = "2026-08-17";
 
 
 export class ParleApiError extends Error {

--- a/packages/client/test/index.test.mjs
+++ b/packages/client/test/index.test.mjs
@@ -64,8 +64,8 @@ test("adapter owns one release-pinned DEFAULT_VERSION without a contract bundle"
   const protocolSrc = readFileSync(new URL("../src/protocol.ts", import.meta.url), "utf8");
   const piSrc = readFileSync(new URL("../../pi-extension/src/index.ts", import.meta.url), "utf8");
   const mcpSrc = readFileSync(new URL("../../mcp-server/src/index.ts", import.meta.url), "utf8");
-  assert.equal(DEFAULT_VERSION, "2026-08-10");
-  assert.match(protocolSrc, /DEFAULT_VERSION = "2026-08-10"/);
+  assert.equal(DEFAULT_VERSION, "2026-08-17");
+  assert.match(protocolSrc, /DEFAULT_VERSION = "2026-08-17"/);
   assert.match(piSrc, /DEFAULT_VERSION[^\n]*from "@parlehq\/agent-client"/);
   assert.doesNotMatch(piSrc, /const DEFAULT_VERSION =/);
   assert.doesNotMatch(mcpSrc, /PARLE_VERSION:/);
@@ -370,7 +370,7 @@ test("PARLE_VERSION is adapter-owned unless explicitly set in process env", () =
   try {
     writeFileSync(join(cwd, ".env"), "PARLE_VERSION=from-dotenv\n");
     const defaultCfg = resolveConfig(cwd, { HOME: cwd });
-    assert.equal(defaultCfg.version.value, "2026-08-10");
+    assert.equal(defaultCfg.version.value, "2026-08-17");
     assert.equal(defaultCfg.version.source, "default");
     assert.match(defaultCfg.warnings.join("\n"), /Ignoring PARLE_VERSION from \.env/);
 
@@ -389,7 +389,7 @@ test("PARLE_VERSION is adapter-owned unless explicitly set in process env", () =
 
     rmSync(join(cwd, ".env"));
     const cleanCfg = resolveConfig(cwd, { HOME: cwd });
-    assert.equal(cleanCfg.version.value, "2026-08-10");
+    assert.equal(cleanCfg.version.value, "2026-08-17");
     assert.equal(cleanCfg.version.source, "default");
     assert.equal(cleanCfg.warnings.length, 0);
   } finally {
@@ -589,11 +589,11 @@ test("requestJson sends one process client identity and rejects reserved caller 
 test("unsupported version errors include source, default, and server versions", async () => {
   const client = new ParleAgentClient({
     env: { PARLE_ROOM_ID: "room-1", PARLE_ROOM_AGENT_TOKEN: "opaque-token", PARLE_VERSION: "bad-version" },
-    fetch: async () => json({ error: { code: "unsupported_parle_version", message: "unsupported Parle-Version header", supported: ["2026-08-10"], current: "2026-08-10" } }, 400),
+    fetch: async () => json({ error: { code: "unsupported_parle_version", message: "unsupported Parle-Version header", supported: ["2026-08-17"], current: "2026-08-17" } }, 400),
   });
   await assert.rejects(
     () => client.requestJson("/v/test"),
-    /Sent Parle-Version bad-version from env; adapter default is 2026-08-10\. Server supports 2026-08-10\. Unset the stale PARLE_VERSION override or upgrade the adapter\./,
+    /Sent Parle-Version bad-version from env; adapter default is 2026-08-17\. Server supports 2026-08-17\. Unset the stale PARLE_VERSION override or upgrade the adapter\./,
   );
 });
 
@@ -1695,7 +1695,7 @@ test("default profile is selected when no explicit binding is configured", () =>
 
 test("version error hint preserves supported-version precedence", () => {
   const cfg = { version: { value: "old", source: "env" } };
-  assert.equal(formatVersionErrorHint(cfg, { supported: ["new"], current: "also-new" }), " Sent Parle-Version old from env; adapter default is 2026-08-10. Server supports new. Unset the stale PARLE_VERSION override or upgrade the adapter.");
+  assert.equal(formatVersionErrorHint(cfg, { supported: ["new"], current: "also-new" }), " Sent Parle-Version old from env; adapter default is 2026-08-17. Server supports new. Unset the stale PARLE_VERSION override or upgrade the adapter.");
 });
 
 test("automatic bootstrap terminal latch fails closed while explicit connect remains a recovery path", async () => {

--- a/packages/client/test/session-lifecycle.test.mjs
+++ b/packages/client/test/session-lifecycle.test.mjs
@@ -47,8 +47,8 @@ test("anonymous session creation sends a closed empty object and the current ver
   });
   await client.connect();
   assert.deepEqual(JSON.parse(seen[0][2]), {});
-  assert.equal(seen[0][3], "2026-08-10");
-  assert.equal(DEFAULT_VERSION, "2026-08-10");
+  assert.equal(seen[0][3], "2026-08-17");
+  assert.equal(DEFAULT_VERSION, "2026-08-17");
   await client.endSession().catch(() => undefined);
 });
 

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.42",
+  "version": "0.6.43",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.42"
+        "PARLE_INTEGRATION_VERSION": "0.6.43"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.43 (2026-08-17)
+
+- Bundle the 2026-08-17 wire version required by the canonical error-contract hard cut (parlehq/parle#810).
+
 ## 0.6.42 (2026-08-17)
 
 - Republish the merged #132 and #140 Codex bundle under a unique version after the concurrent releases shared 0.6.41; runtime behavior is unchanged from main.

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -31575,7 +31575,7 @@ function parseErrorEnvelope(value) {
 }
 
 // ../client/dist/protocol.js
-var DEFAULT_VERSION = "2026-08-10";
+var DEFAULT_VERSION = "2026-08-17";
 var ParleApiError = class extends Error {
   status;
   code;
@@ -39256,7 +39256,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.42";
+var MCP_CLIENT_VERSION = "0.7.43";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.42",
+  "version": "0.6.43",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.23 (2026-08-17)
+
+- Bundle the 2026-08-17 wire version required by the canonical error-contract hard cut (parlehq/parle#810).
+
 ## 0.7.22 (2026-08-17)
 
 - Republish the merged #132 and #140 Command Code bundle under a unique version after the concurrent releases shared 0.7.21; runtime behavior is unchanged from main.

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -621,7 +621,7 @@ function parseErrorEnvelope(value) {
 }
 
 // ../client/dist/protocol.js
-var DEFAULT_VERSION = "2026-08-10";
+var DEFAULT_VERSION = "2026-08-17";
 var ParleApiError = class extends Error {
   status;
   code;
@@ -22346,7 +22346,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var ADAPTER_NAME = "@parlehq/command-code-adapter";
-var ADAPTER_VERSION = "0.7.22";
+var ADAPTER_VERSION = "0.7.23";
 var CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 var STATUS_INTERVAL_MS = 5e3;
 var SYSTEM_GUIDANCE = [

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/src/index.ts
+++ b/packages/command-code/src/index.ts
@@ -3,7 +3,7 @@ import { registerParleTools, type DegradedMcpBoot, type ParleMcpClientLike, type
 import { z } from "zod";
 
 const ADAPTER_NAME = "@parlehq/command-code-adapter";
-const ADAPTER_VERSION = "0.7.22";
+const ADAPTER_VERSION = "0.7.23";
 const CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 const STATUS_INTERVAL_MS = 5_000;
 

--- a/packages/command-code/test/index.test.mjs
+++ b/packages/command-code/test/index.test.mjs
@@ -61,7 +61,7 @@ test("root and package manifests expose only the native mod", () => {
   const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
   assert.deepEqual(root.commandcode.mods, ["./packages/command-code/mods/parle.ts"]);
   assert.deepEqual(pkg.commandcode.mods, ["./mods/parle.ts"]);
-  assert.equal(pkg.version, "0.7.22");
+  assert.equal(pkg.version, "0.7.23");
   assert.match(readFileSync(resolve("src/index.ts"), "utf8"), new RegExp(`ADAPTER_VERSION = "${pkg.version}"`));
 
   const artifact = readFileSync(resolve("mods/parle.ts"), "utf8");

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.43 (2026-08-17)
+
+- Bundle @parlehq/agent-client 0.8.39 with the sole 2026-08-17 wire version (parlehq/parle#810).
+
 ## 0.7.42 (2026-08-17)
 
 - Republish the merged #132 and #140 MCP runtime under a unique version after the concurrent releases shared 0.7.41; runtime behavior is unchanged from main.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,7 +12,7 @@ import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, 
 export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.42";
+export const MCP_CLIENT_VERSION = "0.7.43";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.47 (2026-08-17)
+
+- Bundle the 2026-08-17 wire version required by the canonical error-contract hard cut (parlehq/parle#810).
+
 ## 0.7.46 (2026-08-17)
 
 - Republish the merged #132 and #140 Pi bundle under a unique version after the concurrent releases shared 0.7.45; runtime behavior is unchanged from main.

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -619,7 +619,7 @@ function parseErrorEnvelope(value) {
 }
 
 // ../client/dist/protocol.js
-var DEFAULT_VERSION = "2026-08-10";
+var DEFAULT_VERSION = "2026-08-17";
 var ParleApiError = class extends Error {
   status;
   code;
@@ -6788,7 +6788,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.46";
+var PI_EXTENSION_VERSION = "0.7.47";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.46";
+const PI_EXTENSION_VERSION = "0.7.47";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -112,7 +112,7 @@ test("status ignores persisted PARLE_VERSION and warns", async () => {
   globalThis.fetch = async () => { throw new Error("offline test"); };
   const harness = installHarness(cwd);
   const status = await harness.call("parle_status");
-  assert.equal(status.details.version.value, "2026-08-10");
+  assert.equal(status.details.version.value, "2026-08-17");
   assert.equal(status.details.version.source, "default");
   assert.equal(status.details.roomId.value, "room-1");
   assert.match(status.details.warnings.join("\n"), /Ignoring PARLE_VERSION from project \.env/);
@@ -925,7 +925,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", participantId: "p-1", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.46" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.47" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1611,7 +1611,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.46");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.47");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
Coordinates with parlehq/parle#810. Advances the sole adapter wire default to 2026-08-17, bumps every changed installable artifact, and refreshes the canonical Pi, Claude, Command Code, Codex, Desktop, and MCP bundles.\n\nValidation: artifact reproducibility, manifest checks, release-claim checks, typecheck, client and Pi suites pass. The MCP AF_UNIX hook-bridge subset cannot bind sockets in this host tree (EPERM), matching the known host limitation; all non-socket MCP tests pass.\n\nNo runtime negotiation or prior-version fallback is added.