### PR TITLE
fix: tolerate slow hook delivery commits (#151)

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.50 (2026-08-18)
+
+- Refresh the bundled MCP runtime after the shared hook package's bounded commit-timeout correction (#151).
+
 ## 0.8.49 (2026-08-18)
 
 - Refresh the bundled MCP runtime with truthful hook-bridge waiter status (#151).

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.49",
+  "version": "0.8.50",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.49"
+        "PARLE_INTEGRATION_VERSION": "0.8.50"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.49",
+  "version": "0.8.50",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -39650,7 +39650,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.49";
+var MCP_CLIENT_VERSION = "0.7.50";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.54",
+  "version": "0.9.55",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -9,7 +9,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.54"
+        "PARLE_INTEGRATION_VERSION": "0.9.55"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.55 (2026-08-18)
+
+- Allow a slow successful delivery acknowledgement to finish inside Claude's bounded hook window instead of reporting a contradictory local timeout (#151).
+
 ## 0.9.54 (2026-08-18)
 
 - Deliver Stop-boundary messages and idle-wake instructions as non-error hook context instead of Claude's misleading `Stop hook error` rendering.

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -39650,7 +39650,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.49";
+var MCP_CLIENT_VERSION = "0.7.50";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/hooks/parle-hook.mjs
+++ b/packages/claude-plugin/hooks/parle-hook.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 const MAX_INPUT = 256 * 1024;
 const MAX_RESPONSE = 512 * 1024;
 const SOCKET_TIMEOUT_MS = 1000;
+const HOST_HOOK_BUDGET_MS = 4500;
 
 function parseArgs(argv) {
   let bind = false;
@@ -85,11 +86,11 @@ function socketEntries(scope, hostParentPid) {
   }
 }
 
-function request(path, payload) {
+function request(path, payload, timeoutMs = SOCKET_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const socket = connect(path);
     socket.setEncoding("utf8");
-    socket.setTimeout(SOCKET_TIMEOUT_MS, () => socket.destroy(new Error("timeout")));
+    socket.setTimeout(timeoutMs, () => socket.destroy(new Error("timeout")));
     let response = "";
     socket.once("connect", () => socket.write(`${JSON.stringify(payload)}\n`));
     socket.on("data", (chunk) => {
@@ -232,6 +233,7 @@ function reportFailure(error) {
 }
 
 async function main() {
+  const deadline = Date.now() + HOST_HOOK_BUDGET_MS;
   let outputWritten = false;
   try {
     const args = parseArgs(process.argv.slice(2));
@@ -273,7 +275,9 @@ async function main() {
     await writeOutput(output || {});
     outputWritten = true;
     if (!deliveryBatch || !output) return;
-    const committed = await request(deliveryBatch.path, { action: "commit", sessionId, leaseId: deliveryBatch.leaseId });
+    const commitBudgetMs = Math.floor(deadline - Date.now());
+    if (commitBudgetMs <= 0) throw new Error("Parle hook commit budget was exhausted before acknowledgement");
+    const committed = await request(deliveryBatch.path, { action: "commit", sessionId, leaseId: deliveryBatch.leaseId }, commitBudgetMs);
     if (!committed?.ok) throw new Error("Parle hook bridge did not acknowledge the injected batch");
   } catch (error) {
     reportFailure(error);

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.54",
+  "version": "0.9.55",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/claude-plugin/test/delivery.test.mjs
+++ b/packages/claude-plugin/test/delivery.test.mjs
@@ -31,7 +31,7 @@ function cleanupFixture(cwd) {
 let nextOwnerPid = 900_000_000;
 
 // A stub bridge that records every action and answers with a scripted reply.
-function startBridge(scope, { messages, agentSessionId = "parle-agent-session", busy = false, commitOk = true, hostParentPid = process.pid, reportedParentPid = hostParentPid, initialSessionId, waiterAttached = false } = {}) {
+function startBridge(scope, { messages, agentSessionId = "parle-agent-session", bindDelayMs = 0, busy = false, commitDelayMs = 0, commitOk = true, hostParentPid = process.pid, reportedParentPid = hostParentPid, initialSessionId, statusDelayMs = 0, takeDelayMs = 0, waiterAttached = false } = {}) {
   const ownerPid = nextOwnerPid++;
   const dir = join(stateDir(scope), String(hostParentPid));
   mkdirSync(dir, { recursive: true, mode: 0o700 });
@@ -50,15 +50,19 @@ function startBridge(scope, { messages, agentSessionId = "parle-agent-session", 
       buffer = buffer.slice(newline + 1);
       actions.push(command);
       if (command.action === "status") {
-        return void socket.end(`${JSON.stringify({ ok: true, running: true, waiterAttached, agentSessionId, ownerPid, hostParentPid: reportedParentPid, currentParentPid: reportedParentPid })}\n`);
+        return void setTimeout(() => socket.end(`${JSON.stringify({ ok: true, running: true, waiterAttached, agentSessionId, ownerPid, hostParentPid: reportedParentPid, currentParentPid: reportedParentPid })}\n`), statusDelayMs);
       }
       if (command.action === "bind") {
         const ok = !boundSessionId || boundSessionId === command.sessionId || command.allowReplace === true;
         if (ok) boundSessionId = command.sessionId;
-        return void socket.end(`${JSON.stringify({ ok, bound: Boolean(boundSessionId) })}\n`);
+        return void setTimeout(() => socket.end(`${JSON.stringify({ ok, bound: Boolean(boundSessionId) })}\n`), bindDelayMs);
       }
-      if (command.action === "take" && command.sessionId === boundSessionId) return void socket.end(`${JSON.stringify(busy ? { ok: true, busy: true, messages: [] } : { ok: true, leaseId: "lease-1", messages })}\n`);
-      if (command.action === "commit" && command.sessionId === boundSessionId) return void socket.end(`${JSON.stringify(commitOk ? { ok: true, committed: messages.length } : { ok: false })}\n`);
+      if (command.action === "take" && command.sessionId === boundSessionId) {
+        return void setTimeout(() => socket.end(`${JSON.stringify(busy ? { ok: true, busy: true, messages: [] } : { ok: true, leaseId: "lease-1", messages })}\n`), takeDelayMs);
+      }
+      if (command.action === "commit" && command.sessionId === boundSessionId) {
+        return void setTimeout(() => socket.end(`${JSON.stringify(commitOk ? { ok: true, committed: messages.length } : { ok: false })}\n`), commitDelayMs);
+      }
       socket.end(`${JSON.stringify({ ok: false })}\n`);
     });
   });
@@ -237,6 +241,27 @@ test("an invalid idle-wake launcher fails open before bridge IPC", async () => {
     assert.deepEqual(JSON.parse(result.stdout), {});
     assert.match(result.stderr, /idle-wake launcher must be an absolute path/);
     assert.deepEqual(bridge.actions, []);
+  });
+});
+
+test("a slow successful commit completes within the remaining bounded hook budget", async () => {
+  await withBridge({ messages: [deliveredRow(11)], statusDelayMs: 200, bindDelayMs: 200, takeDelayMs: 200, commitDelayMs: 1200 }, async ({ cwd, bridge }) => {
+    const result = await runHook(CLAUDE_ARGS, { hook_event_name: "Stop", session_id: "claude-session", cwd });
+    assert.match(JSON.parse(result.stdout).hookSpecificOutput.additionalContext, /Parle responsive delivery seq=11/);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(bridge.actions.map((action) => action.action), ["status", "bind", "take", "commit"]);
+  });
+});
+
+test("slow pre-commit IPC shrinks the commit deadline below the host hook window", async () => {
+  await withBridge({ messages: [deliveredRow(12)], statusDelayMs: 800, bindDelayMs: 800, takeDelayMs: 800, commitDelayMs: 2500 }, async ({ cwd, bridge }) => {
+    const startedAt = Date.now();
+    const result = await runHook(CLAUDE_ARGS, { hook_event_name: "Stop", session_id: "claude-session", cwd });
+    const elapsedMs = Date.now() - startedAt;
+    assert.match(JSON.parse(result.stdout).hookSpecificOutput.additionalContext, /Parle responsive delivery seq=12/);
+    assert.match(result.stderr, /Parle hook failed open: timeout/);
+    assert.ok(elapsedMs >= 4000 && elapsedMs < 4900, `hook should stop inside its 5s host window, took ${elapsedMs}ms`);
+    assert.deepEqual(bridge.actions.map((action) => action.action), ["status", "bind", "take", "commit"]);
   });
 });
 

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.50",
+  "version": "0.6.51",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.50"
+        "PARLE_INTEGRATION_VERSION": "0.6.51"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.51 (2026-08-18)
+
+- Allow slow successful hook-delivery acknowledgements to complete within the bounded host hook window (#151).
+
 ## 0.6.50 (2026-08-18)
 
 - Keep Codex Stop behavior unchanged while bundling the shared hook's opt-in Claude non-error output mode.

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -39650,7 +39650,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.49";
+var MCP_CLIENT_VERSION = "0.7.50";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/codex-plugin/hooks/parle-hook.mjs
+++ b/packages/codex-plugin/hooks/parle-hook.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 const MAX_INPUT = 256 * 1024;
 const MAX_RESPONSE = 512 * 1024;
 const SOCKET_TIMEOUT_MS = 1000;
+const HOST_HOOK_BUDGET_MS = 4500;
 
 function parseArgs(argv) {
   let bind = false;
@@ -85,11 +86,11 @@ function socketEntries(scope, hostParentPid) {
   }
 }
 
-function request(path, payload) {
+function request(path, payload, timeoutMs = SOCKET_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const socket = connect(path);
     socket.setEncoding("utf8");
-    socket.setTimeout(SOCKET_TIMEOUT_MS, () => socket.destroy(new Error("timeout")));
+    socket.setTimeout(timeoutMs, () => socket.destroy(new Error("timeout")));
     let response = "";
     socket.once("connect", () => socket.write(`${JSON.stringify(payload)}\n`));
     socket.on("data", (chunk) => {
@@ -232,6 +233,7 @@ function reportFailure(error) {
 }
 
 async function main() {
+  const deadline = Date.now() + HOST_HOOK_BUDGET_MS;
   let outputWritten = false;
   try {
     const args = parseArgs(process.argv.slice(2));
@@ -273,7 +275,9 @@ async function main() {
     await writeOutput(output || {});
     outputWritten = true;
     if (!deliveryBatch || !output) return;
-    const committed = await request(deliveryBatch.path, { action: "commit", sessionId, leaseId: deliveryBatch.leaseId });
+    const commitBudgetMs = Math.floor(deadline - Date.now());
+    if (commitBudgetMs <= 0) throw new Error("Parle hook commit budget was exhausted before acknowledgement");
+    const committed = await request(deliveryBatch.path, { action: "commit", sessionId, leaseId: deliveryBatch.leaseId }, commitBudgetMs);
     if (!committed?.ok) throw new Error("Parle hook bridge did not acknowledge the injected batch");
   } catch (error) {
     reportFailure(error);

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.50",
+  "version": "0.6.51",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.50 (2026-08-18)
+
+- Keep synchronous hook delivery commits within the host's bounded Stop window while tolerating acknowledgements slower than the ordinary local IPC timeout (#151).
+
 ## 0.7.49 (2026-08-18)
 
 - Expose socket-derived local waiter attachment, report healthy-but-unarmed idle wake truthfully, and make duplicate watcher attachment a successful no-op (#151).

--- a/packages/mcp-server/hooks/parle-hook.mjs
+++ b/packages/mcp-server/hooks/parle-hook.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 const MAX_INPUT = 256 * 1024;
 const MAX_RESPONSE = 512 * 1024;
 const SOCKET_TIMEOUT_MS = 1000;
+const HOST_HOOK_BUDGET_MS = 4500;
 
 function parseArgs(argv) {
   let bind = false;
@@ -85,11 +86,11 @@ function socketEntries(scope, hostParentPid) {
   }
 }
 
-function request(path, payload) {
+function request(path, payload, timeoutMs = SOCKET_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const socket = connect(path);
     socket.setEncoding("utf8");
-    socket.setTimeout(SOCKET_TIMEOUT_MS, () => socket.destroy(new Error("timeout")));
+    socket.setTimeout(timeoutMs, () => socket.destroy(new Error("timeout")));
     let response = "";
     socket.once("connect", () => socket.write(`${JSON.stringify(payload)}\n`));
     socket.on("data", (chunk) => {
@@ -232,6 +233,7 @@ function reportFailure(error) {
 }
 
 async function main() {
+  const deadline = Date.now() + HOST_HOOK_BUDGET_MS;
   let outputWritten = false;
   try {
     const args = parseArgs(process.argv.slice(2));
@@ -273,7 +275,9 @@ async function main() {
     await writeOutput(output || {});
     outputWritten = true;
     if (!deliveryBatch || !output) return;
-    const committed = await request(deliveryBatch.path, { action: "commit", sessionId, leaseId: deliveryBatch.leaseId });
+    const commitBudgetMs = Math.floor(deadline - Date.now());
+    if (commitBudgetMs <= 0) throw new Error("Parle hook commit budget was exhausted before acknowledgement");
+    const committed = await request(deliveryBatch.path, { action: "commit", sessionId, leaseId: deliveryBatch.leaseId }, commitBudgetMs);
     if (!committed?.ok) throw new Error("Parle hook bridge did not acknowledge the injected batch");
   } catch (error) {
     reportFailure(error);

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.49",
+  "version": "0.7.50",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,7 +12,7 @@ import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, 
 export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.49";
+export const MCP_CLIENT_VERSION = "0.7.50";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {


### PR DESCRIPTION
## Summary

- keep ordinary hook bridge IPC at the existing 1s timeout
- derive the commit deadline from the remaining 4.5s total hook budget inside Claude's 5s host window
- cover both a slow successful commit and slow pre-commit IPC that shrinks the commit deadline
- publish follow-up versions after the live 0.9.53 canary exposed a contradictory local timeout

## Live evidence

Exact 0.9.53 passed repeated idle wake, automatic re-attachment, opaque replies, and concurrent same-cwd isolation. One concurrent delivery wrote the correct context and eventually acknowledged, but the hook reported `Parle hook failed open: timeout` after the ordinary 1s local IPC deadline. The row did not redeliver. This patch removes that contradiction without widening status, bind, or take deadlines or allowing their elapsed time plus commit to exceed the host hook window.

## Validation

- `pnpm -F @parlehq/claude-plugin test`
- `pnpm -F @parlehq/mcp-server test`
- `pnpm typecheck`
- `pnpm check:manifests`
- `node scripts/check-release-claims.mjs origin/main`
- `pnpm check:mcp-artifacts`
- `git diff --check`

#151 remains open until exact 0.9.54 bytes pass the live pressure gate.
