### PR TITLE
Fix Pi watcher startup retry deadline race

### DIFF
--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.54 (2026-08-19)
+
+- Preserve autonomous startup bootstrap retries when a timer wakes just before the server retry deadline (#139).
+
 ## 0.7.53 (2026-08-18)
 
 - Refresh the bundled client with stage-accurate responsive-delivery progress and additive acknowledgement evidence (#157).

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -7264,7 +7264,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.53";
+var PI_EXTENSION_VERSION = "0.7.54";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";
@@ -8301,8 +8301,11 @@ async function runWatcher(pi, ctx, cfg, signal, runId) {
       watcherLoopRunning = false;
       setStatus(ctx, cfg);
       if (!terminalState && !runtime.rateLimitParkedCause && retryableError(error)) {
-        const retryDelay = runtime.nextRetryAt ? Math.max(0, Date.parse(runtime.nextRetryAt) - wallNowMs()) : watcherRetryDelayMs(error);
-        await watcherSleep(retryDelay, signal).catch(() => void 0);
+        let retryDelay = runtime.nextRetryAt ? Math.max(0, Date.parse(runtime.nextRetryAt) - wallNowMs()) : watcherRetryDelayMs(error);
+        while (retryDelay > 0 && !signal.aborted) {
+          await watcherSleep(retryDelay, signal).catch(() => void 0);
+          retryDelay = runtime.nextRetryAt ? Math.max(0, Date.parse(runtime.nextRetryAt) - wallNowMs()) : 0;
+        }
         if (!signal.aborted && runId === activeWatcherRunId && !maybeParkRateLimitedWatcher() && !shutdownRequested && !lifecycleEnded) {
           startWatcher(pi, ctx, cfg);
         }

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.53",
+  "version": "0.7.54",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.53";
+const PI_EXTENSION_VERSION = "0.7.54";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.
@@ -1447,8 +1447,11 @@ async function runWatcher(pi: any, ctx: any, cfg: ParleConfig, signal: AbortSign
       watcherLoopRunning = false;
       setStatus(ctx, cfg);
       if (!terminalState && !runtime.rateLimitParkedCause && retryableError(error)) {
-        const retryDelay = runtime.nextRetryAt ? Math.max(0, Date.parse(runtime.nextRetryAt) - wallNowMs()) : watcherRetryDelayMs(error);
-        await watcherSleep(retryDelay, signal).catch(() => undefined);
+        let retryDelay = runtime.nextRetryAt ? Math.max(0, Date.parse(runtime.nextRetryAt) - wallNowMs()) : watcherRetryDelayMs(error);
+        while (retryDelay > 0 && !signal.aborted) {
+          await watcherSleep(retryDelay, signal).catch(() => undefined);
+          retryDelay = runtime.nextRetryAt ? Math.max(0, Date.parse(runtime.nextRetryAt) - wallNowMs()) : 0;
+        }
         if (!signal.aborted && runId === activeWatcherRunId && !maybeParkRateLimitedWatcher() && !shutdownRequested && !lifecycleEnded) {
           startWatcher(pi, ctx, cfg);
         }

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -521,6 +521,12 @@ test("watcher bootstrap failure records status instead of escaping", async () =>
 test("watcher autonomously retries a retryable startup bootstrap failure", async () => {
   const cwd = tempProject("PARLE_ROOM_ID=room-1\nPARLE_ROOM_AGENT_TOKEN=token-1\n");
   let sessionCreates = 0;
+  let wall = 1_000_000;
+  let releaseRetry;
+  let retrySleepStarted;
+  let unsubscribe;
+  let timeout;
+  const retrySleep = new Promise((resolve) => { retrySleepStarted = resolve; });
   globalThis.fetch = async (url) => {
     const u = String(url);
     if (u.endsWith("/v/agent/sessions")) {
@@ -536,12 +542,51 @@ test("watcher autonomously retries a retryable startup bootstrap failure", async
     if (u.endsWith("/v/agent/wake")) return new Response(new ReadableStream({ start() {} }), { status: 200 });
     throw new Error(`unexpected ${u}`);
   };
+  __testing.setWatcherTiming({
+    wallNowMs: () => wall,
+    sleep(ms, signal) {
+      if (releaseRetry) {
+        wall += ms;
+        return Promise.resolve();
+      }
+      assert.equal(ms, 20);
+      retrySleepStarted();
+      return new Promise((resolve, reject) => {
+        const onAbort = () => reject(new Error("aborted"));
+        signal?.addEventListener("abort", onAbort, { once: true });
+        releaseRetry = () => {
+          signal?.removeEventListener("abort", onAbort);
+          wall += 19;
+          resolve();
+        };
+      });
+    },
+  });
   const ctx = { cwd, ui: { setStatus() {} } };
-  __testing.startWatcher({ sendUserMessage() {} }, ctx, __testing.resolveConfig(cwd));
-  await eventually(() => __testing.runtimeState().bootstrapped === true);
-  assert.equal(sessionCreates, 2);
-  assert.equal(__testing.runtimeState().agentSessionId, "as-auto-retry");
-  __testing.resetRuntime();
+  try {
+    __testing.startWatcher({ sendUserMessage() {} }, ctx, __testing.resolveConfig(cwd));
+    await retrySleep;
+    assert.equal(sessionCreates, 1);
+    assert.equal(__testing.runtimeState().bootstrapped, false);
+    const bootstrapCommitted = new Promise((resolve) => {
+      unsubscribe = __testing.agentClient().onSessionRevision((event) => {
+        if (event.reason === "bootstrap") resolve();
+      });
+    });
+    releaseRetry();
+    await Promise.race([
+      bootstrapCommitted,
+      new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error("bootstrap retry did not commit")), 250); }),
+    ]);
+    assert.equal(sessionCreates, 2);
+    assert.equal(__testing.runtimeState().bootstrapped, true);
+    assert.equal(__testing.runtimeState().agentSessionId, "as-auto-retry");
+  } finally {
+    clearTimeout(timeout);
+    unsubscribe?.();
+    __testing.resetRuntime();
+    await new Promise((resolve) => setImmediate(resolve));
+  }
 });
 
 function installWatcherFailureHarness(wakeResponse) {
@@ -925,7 +970,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", participantId: "p-1", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.53" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.54" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1611,7 +1656,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.53");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.54");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- deterministically reproduce the early retry-timer boundary
- wait through any remaining server retry deadline before restarting the watcher
- synchronize the regression test on the bootstrap commit event
- release Pi extension 0.7.53 with the refreshed bundle

## Validation

- focused regression test fails before the production fix and passes after it
- 100 fresh-process focused runs passed
- Pi package tests passed with ambient `PARLE_PROFILE` and `PARLE_SESSION_ALIAS`
- root typecheck and release-claim checks passed
- root tests passed all workspaces except pre-existing local macOS Codex Unix-socket tests, which fail with `listen EPERM` on their long `/tmp` socket paths
- independent concurrency review: LGTM

Fixes #139
