### PR TITLE
Fix responsive-delivery acknowledgement progress (#157)

### DIFF
--- a/docs/design/adapter-topology.md
+++ b/docs/design/adapter-topology.md
@@ -276,7 +276,7 @@ Responsive-delivery errors retain ownership:
 - Bridge errors carry bridge-owned `lastErrorKind` of `listen`, `startup`, `controller`, or `evidence`.
 - Flattened bridge status carries `lastErrorSource` of `bridge`, `controller`, or `room`. Direct bridge errors currently have source and kind but no independent bridge timestamp.
 
-Success clears only an error in the same owning domain. Unrelated fetch or wake success must not erase a handler or acknowledgement failure. Current `lastSuccessAt` progress remains broader than effective handling or acknowledgement; [issue #157](https://github.com/parlehq/parle-adapters/issues/157) owns that separate evidence refinement.
+Success clears only an error in the same owning domain. Unrelated fetch or wake success must not erase a handler or acknowledgement failure. `lastSuccessAt` records delivery-loop liveness from wake opens and successful fetches, while additive `lastAckAt` records the latest successful acknowledgement. Neither clock proves that a model turn began or completed.
 
 ## Verification map
 

--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.53 (2026-08-18)
+
+- Expose additive responsive-delivery acknowledgement evidence while preserving fetch liveness (#157).
+
 ## 0.8.52 (2026-08-18)
 
 - Publish the complete #156 room-recovery diagnostic fix under a unique Desktop extension version.

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.52"
+        "PARLE_INTEGRATION_VERSION": "0.8.53"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -32379,6 +32379,7 @@ function buildResponsiveDeliverySnapshot(base, state, event = {}, now = /* @__PU
     updatedAt,
     expiresAt,
     ...event.lastSuccessAt ? { lastSuccessAt: event.lastSuccessAt } : {},
+    ...event.lastAckAt ? { lastAckAt: event.lastAckAt } : {},
     ...event.lastWakeAt ? { lastWakeAt: event.lastWakeAt } : {},
     ...event.retryAt ? { retryAt: event.retryAt } : {},
     ...message ? { lastError: { message, at: errorAt } } : {},
@@ -32429,7 +32430,7 @@ function parseResponsiveDeliverySnapshot(value) {
     updatedAt: row.updatedAt,
     expiresAt: row.expiresAt
   };
-  for (const key of ["lastSuccessAt", "lastWakeAt", "retryAt"])
+  for (const key of ["lastSuccessAt", "lastAckAt", "lastWakeAt", "retryAt"])
     if (ISO(row[key]))
       snapshot[key] = row[key];
   if (row.lastError && ISO(row.lastError.at) && typeof row.lastError.message === "string")
@@ -32491,7 +32492,7 @@ function isActiveLive(snapshot, now, inspectPid) {
 function result(state, snapshot, now = /* @__PURE__ */ new Date()) {
   if (!snapshot)
     return { state };
-  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
+  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastAckAt ? { lastAckAt: snapshot.lastAckAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
 }
 function resolveResponsiveDelivery(snapshots, agentSessionId, options = {}) {
   const now = options.now || /* @__PURE__ */ new Date();
@@ -32622,7 +32623,13 @@ var ResponsiveDeliveryRecorder = class {
     this.target = { ...options.target };
   }
   record(state, event = {}) {
-    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, event, this.options.now?.() || /* @__PURE__ */ new Date());
+    const carried = this.latest?.target.agentSessionId === this.target.agentSessionId ? this.latest : void 0;
+    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, {
+      ...event,
+      ...state === "watching" && !event.lastSuccessAt && carried?.lastSuccessAt ? { lastSuccessAt: carried.lastSuccessAt } : {},
+      ...!event.lastAckAt && carried?.lastAckAt ? { lastAckAt: carried.lastAckAt } : {},
+      ...state === "watching" && !event.lastWakeAt && carried?.lastWakeAt ? { lastWakeAt: carried.lastWakeAt } : {}
+    }, this.options.now?.() || /* @__PURE__ */ new Date());
     this.latest = snapshot;
     if (this.options.persist && this.options.cwd)
       writeResponsiveDeliverySnapshot(this.options.cwd, snapshot);
@@ -35737,6 +35744,11 @@ var ResponsiveDeliveryController = class {
     if (this.seen.has(key))
       return true;
     const stat = this.stat(roomId);
+    const deferred = this.deferred.get(key);
+    if (deferred && !deferred.completionReported) {
+      deferred.completionReported = true;
+      this.reportProgress("handling_complete");
+    }
     try {
       await this.client.ackResponsiveDelivery(message, this.abort.signal, roomId);
     } catch (error51) {
@@ -35744,6 +35756,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(roomId, "ack");
+    this.reportProgress("ack_success");
     this.deferred.delete(key);
     this.handled.delete(key);
     this.remember(key);
@@ -35966,7 +35979,7 @@ var ResponsiveDeliveryController = class {
       try {
         delivery = await this.client.drainResponsiveDelivery(this.abort.signal, room.roomId);
         this.clearRoomError(room.roomId, "drain");
-        this.reportProgress("drain_success");
+        this.reportProgress("fetch_success");
       } catch (error51) {
         this.setRoomError(room.roomId, "drain", error51);
         return;
@@ -36017,6 +36030,7 @@ var ResponsiveDeliveryController = class {
           this.deferred.set(key, { roomId: room.roomId, message });
           return true;
         }
+        this.reportProgress("handling_complete");
       } catch (error51) {
         const attempts = (this.attempts.get(key) || 0) + 1;
         this.attempts.set(key, attempts);
@@ -36037,6 +36051,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(room.roomId, "ack");
+    this.reportProgress("ack_success");
     this.handled.delete(key);
     this.remember(key);
     if (outcome === "intentionally_skipped")
@@ -38622,7 +38637,15 @@ var HookDeliveryBridge = class {
     this.controller = new ResponsiveDeliveryController(client, {
       handler: (input) => this.handleDelivery(input),
       maxHandlerAttempts: Number.MAX_SAFE_INTEGER,
-      onProgress: () => this.publishEvidence("watching", { expectedProgressMs: 57e4, lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() }),
+      onProgress: (kind) => {
+        const at = (/* @__PURE__ */ new Date()).toISOString();
+        this.publishEvidence("watching", {
+          expectedProgressMs: 57e4,
+          ...["wake_open", "fetch_success"].includes(kind) ? { lastSuccessAt: at } : {},
+          ...kind === "wake_open" ? { lastWakeAt: at } : {},
+          ...kind === "ack_success" ? { lastAckAt: at } : {}
+        });
+      },
       onWakeError: (error51) => {
         const message = error51 instanceof Error ? error51.message : String(error51);
         const action = typeof error51 === "object" && error51 !== null ? error51.action : void 0;
@@ -38732,7 +38755,7 @@ var HookDeliveryBridge = class {
         this.baselineDone = true;
         this.lastError = void 0;
         this.lastErrorKind = void 0;
-        this.publishEvidence("watching", { expectedProgressMs: 57e4, lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() });
+        this.publishEvidence("watching", { expectedProgressMs: 57e4 });
       } catch (error51) {
         this.lastError = error51 instanceof Error ? error51.message : String(error51);
         this.lastErrorKind = "controller";
@@ -39672,7 +39695,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.52";
+var MCP_CLIENT_VERSION = "0.7.53";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -9,7 +9,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.57"
+        "PARLE_INTEGRATION_VERSION": "0.9.58"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.58 (2026-08-18)
+
+- Expose additive responsive-delivery acknowledgement evidence while preserving fetch liveness (#157).
+
 ## 0.9.57 (2026-08-18)
 
 - Publish the complete #156 room-recovery diagnostic fix under a unique Claude plugin version.

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -32379,6 +32379,7 @@ function buildResponsiveDeliverySnapshot(base, state, event = {}, now = /* @__PU
     updatedAt,
     expiresAt,
     ...event.lastSuccessAt ? { lastSuccessAt: event.lastSuccessAt } : {},
+    ...event.lastAckAt ? { lastAckAt: event.lastAckAt } : {},
     ...event.lastWakeAt ? { lastWakeAt: event.lastWakeAt } : {},
     ...event.retryAt ? { retryAt: event.retryAt } : {},
     ...message ? { lastError: { message, at: errorAt } } : {},
@@ -32429,7 +32430,7 @@ function parseResponsiveDeliverySnapshot(value) {
     updatedAt: row.updatedAt,
     expiresAt: row.expiresAt
   };
-  for (const key of ["lastSuccessAt", "lastWakeAt", "retryAt"])
+  for (const key of ["lastSuccessAt", "lastAckAt", "lastWakeAt", "retryAt"])
     if (ISO(row[key]))
       snapshot[key] = row[key];
   if (row.lastError && ISO(row.lastError.at) && typeof row.lastError.message === "string")
@@ -32491,7 +32492,7 @@ function isActiveLive(snapshot, now, inspectPid) {
 function result(state, snapshot, now = /* @__PURE__ */ new Date()) {
   if (!snapshot)
     return { state };
-  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
+  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastAckAt ? { lastAckAt: snapshot.lastAckAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
 }
 function resolveResponsiveDelivery(snapshots, agentSessionId, options = {}) {
   const now = options.now || /* @__PURE__ */ new Date();
@@ -32622,7 +32623,13 @@ var ResponsiveDeliveryRecorder = class {
     this.target = { ...options.target };
   }
   record(state, event = {}) {
-    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, event, this.options.now?.() || /* @__PURE__ */ new Date());
+    const carried = this.latest?.target.agentSessionId === this.target.agentSessionId ? this.latest : void 0;
+    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, {
+      ...event,
+      ...state === "watching" && !event.lastSuccessAt && carried?.lastSuccessAt ? { lastSuccessAt: carried.lastSuccessAt } : {},
+      ...!event.lastAckAt && carried?.lastAckAt ? { lastAckAt: carried.lastAckAt } : {},
+      ...state === "watching" && !event.lastWakeAt && carried?.lastWakeAt ? { lastWakeAt: carried.lastWakeAt } : {}
+    }, this.options.now?.() || /* @__PURE__ */ new Date());
     this.latest = snapshot;
     if (this.options.persist && this.options.cwd)
       writeResponsiveDeliverySnapshot(this.options.cwd, snapshot);
@@ -35737,6 +35744,11 @@ var ResponsiveDeliveryController = class {
     if (this.seen.has(key))
       return true;
     const stat = this.stat(roomId);
+    const deferred = this.deferred.get(key);
+    if (deferred && !deferred.completionReported) {
+      deferred.completionReported = true;
+      this.reportProgress("handling_complete");
+    }
     try {
       await this.client.ackResponsiveDelivery(message, this.abort.signal, roomId);
     } catch (error51) {
@@ -35744,6 +35756,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(roomId, "ack");
+    this.reportProgress("ack_success");
     this.deferred.delete(key);
     this.handled.delete(key);
     this.remember(key);
@@ -35966,7 +35979,7 @@ var ResponsiveDeliveryController = class {
       try {
         delivery = await this.client.drainResponsiveDelivery(this.abort.signal, room.roomId);
         this.clearRoomError(room.roomId, "drain");
-        this.reportProgress("drain_success");
+        this.reportProgress("fetch_success");
       } catch (error51) {
         this.setRoomError(room.roomId, "drain", error51);
         return;
@@ -36017,6 +36030,7 @@ var ResponsiveDeliveryController = class {
           this.deferred.set(key, { roomId: room.roomId, message });
           return true;
         }
+        this.reportProgress("handling_complete");
       } catch (error51) {
         const attempts = (this.attempts.get(key) || 0) + 1;
         this.attempts.set(key, attempts);
@@ -36037,6 +36051,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(room.roomId, "ack");
+    this.reportProgress("ack_success");
     this.handled.delete(key);
     this.remember(key);
     if (outcome === "intentionally_skipped")
@@ -38622,7 +38637,15 @@ var HookDeliveryBridge = class {
     this.controller = new ResponsiveDeliveryController(client, {
       handler: (input) => this.handleDelivery(input),
       maxHandlerAttempts: Number.MAX_SAFE_INTEGER,
-      onProgress: () => this.publishEvidence("watching", { expectedProgressMs: 57e4, lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() }),
+      onProgress: (kind) => {
+        const at = (/* @__PURE__ */ new Date()).toISOString();
+        this.publishEvidence("watching", {
+          expectedProgressMs: 57e4,
+          ...["wake_open", "fetch_success"].includes(kind) ? { lastSuccessAt: at } : {},
+          ...kind === "wake_open" ? { lastWakeAt: at } : {},
+          ...kind === "ack_success" ? { lastAckAt: at } : {}
+        });
+      },
       onWakeError: (error51) => {
         const message = error51 instanceof Error ? error51.message : String(error51);
         const action = typeof error51 === "object" && error51 !== null ? error51.action : void 0;
@@ -38732,7 +38755,7 @@ var HookDeliveryBridge = class {
         this.baselineDone = true;
         this.lastError = void 0;
         this.lastErrorKind = void 0;
-        this.publishEvidence("watching", { expectedProgressMs: 57e4, lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() });
+        this.publishEvidence("watching", { expectedProgressMs: 57e4 });
       } catch (error51) {
         this.lastError = error51 instanceof Error ? error51.message : String(error51);
         this.lastErrorKind = "controller";
@@ -39672,7 +39695,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.52";
+var MCP_CLIENT_VERSION = "0.7.53";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/claude-plugin/statusline/responsive-delivery-reader.mjs
+++ b/packages/claude-plugin/statusline/responsive-delivery-reader.mjs
@@ -75,6 +75,7 @@ export function buildResponsiveDeliverySnapshot(base, state, event = {}, now = n
     return cleanSnapshot({
         ...base, schemaVersion: 1, state, updatedAt, expiresAt,
         ...(event.lastSuccessAt ? { lastSuccessAt: event.lastSuccessAt } : {}),
+        ...(event.lastAckAt ? { lastAckAt: event.lastAckAt } : {}),
         ...(event.lastWakeAt ? { lastWakeAt: event.lastWakeAt } : {}),
         ...(event.retryAt ? { retryAt: event.retryAt } : {}),
         ...(message ? { lastError: { message, at: errorAt } } : {}),
@@ -119,7 +120,7 @@ export function parseResponsiveDeliverySnapshot(value) {
         target: { agentSessionId, ...(string(row.target.participantId) ? { participantId: string(row.target.participantId) } : {}), ...(string(row.target.roomId) ? { roomId: string(row.target.roomId) } : {}) },
         state: row.state, updatedAt: row.updatedAt, expiresAt: row.expiresAt,
     };
-    for (const key of ["lastSuccessAt", "lastWakeAt", "retryAt"])
+    for (const key of ["lastSuccessAt", "lastAckAt", "lastWakeAt", "retryAt"])
         if (ISO(row[key]))
             snapshot[key] = row[key];
     if (row.lastError && ISO(row.lastError.at) && typeof row.lastError.message === "string")
@@ -183,7 +184,7 @@ function isActiveLive(snapshot, now, inspectPid) {
 function result(state, snapshot, now = new Date()) {
     if (!snapshot)
         return { state };
-    return { state, updatedAt: snapshot.updatedAt, ...(snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}), ...(snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}), ...(snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}), ...(snapshot.lastError ? { lastError: snapshot.lastError } : {}), ...(snapshot.reason ? { reason: snapshot.reason } : {}), evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...(snapshot.publisher.version ? { version: snapshot.publisher.version } : {}) } };
+    return { state, updatedAt: snapshot.updatedAt, ...(snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}), ...(snapshot.lastAckAt ? { lastAckAt: snapshot.lastAckAt } : {}), ...(snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}), ...(snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}), ...(snapshot.lastError ? { lastError: snapshot.lastError } : {}), ...(snapshot.reason ? { reason: snapshot.reason } : {}), evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...(snapshot.publisher.version ? { version: snapshot.publisher.version } : {}) } };
 }
 /** Pure selection: target identity is agentSessionId, never clientInstanceId. */
 export function resolveResponsiveDelivery(snapshots, agentSessionId, options = {}) {
@@ -326,7 +327,13 @@ export class ResponsiveDeliveryRecorder {
         this.target = { ...options.target };
     }
     record(state, event = {}) {
-        const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, event, this.options.now?.() || new Date());
+        const carried = this.latest?.target.agentSessionId === this.target.agentSessionId ? this.latest : undefined;
+        const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, {
+            ...event,
+            ...(state === "watching" && !event.lastSuccessAt && carried?.lastSuccessAt ? { lastSuccessAt: carried.lastSuccessAt } : {}),
+            ...(!event.lastAckAt && carried?.lastAckAt ? { lastAckAt: carried.lastAckAt } : {}),
+            ...(state === "watching" && !event.lastWakeAt && carried?.lastWakeAt ? { lastWakeAt: carried.lastWakeAt } : {}),
+        }, this.options.now?.() || new Date());
         this.latest = snapshot;
         if (this.options.persist && this.options.cwd)
             writeResponsiveDeliverySnapshot(this.options.cwd, snapshot);

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.46 (2026-08-18)
+
+- Distinguish wake, fetch, handling, and acknowledgement progress while preserving liveness and adding `lastAckAt` evidence (#157).
+
 ## 0.8.45 (2026-08-18)
 
 - Publish the complete #156 room-recovery diagnostic fix under a unique client version.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/agent-client",
-  "version": "0.8.45",
+  "version": "0.8.46",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/client/src/delivery.ts
+++ b/packages/client/src/delivery.ts
@@ -50,11 +50,12 @@ export type DeliveryControllerOptions = {
   // start(), this fires for every internal reconnect so host connectivity
   // state follows the live stream instead of the most recent failure.
   onWakeOpen?: () => void;
-  // Observed delivery-loop progress only: a wake stream opened or a
-  // responsive-delivery drain completed successfully. Host diagnostics must
-  // remain best-effort and must not interrupt delivery when this callback fails.
-  onProgress?: (kind: "wake_open" | "drain_success") => void;
+  // Observed delivery stages. Host diagnostics must remain best-effort and
+  // must not interrupt delivery when this callback fails.
+  onProgress?: (kind: DeliveryProgressKind) => void;
 };
+
+export type DeliveryProgressKind = "wake_open" | "fetch_success" | "handling_complete" | "ack_success";
 
 export type DeliveryErrorDomain = "recover" | "drain" | "handler" | "ack";
 
@@ -121,7 +122,7 @@ export class ResponsiveDeliveryController {
   private readonly random: () => number;
   private readonly onWakeError?: (error: unknown) => "continue" | "stop" | void;
   private readonly onWakeOpen?: () => void;
-  private readonly onProgress?: (kind: "wake_open" | "drain_success") => void;
+  private readonly onProgress?: (kind: DeliveryProgressKind) => void;
   private readonly now: () => Date;
   // Deduplication is keyed by (roomId, eventId) and deliberately survives
   // session replacement: a new participant restarts server-side ack state, so
@@ -137,7 +138,7 @@ export class ResponsiveDeliveryController {
   // Rows a host accepted for later effective handling. They are never
   // re-offered to the handler and never acknowledged until the host reports
   // completion, so a crash before injection leaves the row redeliverable.
-  private readonly deferred = new Map<string, { roomId: string; message: ResponsiveDeliveryMessage }>();
+  private readonly deferred = new Map<string, { roomId: string; message: ResponsiveDeliveryMessage; completionReported?: boolean }>();
   private readonly drainInFlight = new Map<string, Promise<void>>();
   private loop?: Promise<void>;
   private unsubscribeRevision?: () => void;
@@ -228,6 +229,11 @@ export class ResponsiveDeliveryController {
     const key = deliveryKey(roomId, message);
     if (this.seen.has(key)) return true;
     const stat = this.stat(roomId);
+    const deferred = this.deferred.get(key);
+    if (deferred && !deferred.completionReported) {
+      deferred.completionReported = true;
+      this.reportProgress("handling_complete");
+    }
     try {
       await this.client.ackResponsiveDelivery(message, this.abort.signal, roomId);
     } catch (error) {
@@ -235,6 +241,7 @@ export class ResponsiveDeliveryController {
       return false;
     }
     this.clearRoomError(roomId, "ack");
+    this.reportProgress("ack_success");
     this.deferred.delete(key);
     this.handled.delete(key);
     this.remember(key);
@@ -452,7 +459,7 @@ export class ResponsiveDeliveryController {
     if (stat.lastError?.domain === domain) stat.lastError = undefined;
   }
 
-  private reportProgress(kind: "wake_open" | "drain_success"): void {
+  private reportProgress(kind: DeliveryProgressKind): void {
     try { this.onProgress?.(kind); } catch { /* diagnostics never interrupt delivery */ }
   }
 
@@ -463,7 +470,7 @@ export class ResponsiveDeliveryController {
       try {
         delivery = await this.client.drainResponsiveDelivery(this.abort.signal, room.roomId);
         this.clearRoomError(room.roomId, "drain");
-        this.reportProgress("drain_success");
+        this.reportProgress("fetch_success");
       } catch (error) {
         this.setRoomError(room.roomId, "drain", error);
         return;
@@ -517,6 +524,7 @@ export class ResponsiveDeliveryController {
           this.deferred.set(key, { roomId: room.roomId, message });
           return true;
         }
+        this.reportProgress("handling_complete");
       } catch (error) {
         const attempts = (this.attempts.get(key) || 0) + 1;
         this.attempts.set(key, attempts);
@@ -540,6 +548,7 @@ export class ResponsiveDeliveryController {
       return false;
     }
     this.clearRoomError(room.roomId, "ack");
+    this.reportProgress("ack_success");
     this.handled.delete(key);
     this.remember(key);
     if (outcome === "intentionally_skipped") stat.skipped += 1;

--- a/packages/client/src/responsive-delivery.ts
+++ b/packages/client/src/responsive-delivery.ts
@@ -23,6 +23,7 @@ export type ResponsiveDeliverySnapshot = {
   updatedAt: string;
   expiresAt: string;
   lastSuccessAt?: string;
+  lastAckAt?: string;
   lastWakeAt?: string;
   retryAt?: string;
   lastError?: { message: string; at: string };
@@ -32,6 +33,7 @@ export type ResponsiveDeliveryResult = {
   state: ResponsiveDeliveryState;
   updatedAt?: string;
   lastSuccessAt?: string;
+  lastAckAt?: string;
   lastWakeAt?: string;
   retryAt?: string;
   lastError?: { message: string; at: string };
@@ -52,6 +54,7 @@ export type ResponsiveDeliveryPruneOptions = ResponsiveDeliveryResolveOptions & 
 export type ResponsiveDeliveryEvent = {
   expectedProgressMs?: number;
   lastSuccessAt?: string;
+  lastAckAt?: string;
   lastWakeAt?: string;
   retryAt?: string;
   lastError?: { message: string; at?: string } | string;
@@ -137,6 +140,7 @@ export function buildResponsiveDeliverySnapshot(
   return cleanSnapshot({
     ...base, schemaVersion: 1, state, updatedAt, expiresAt,
     ...(event.lastSuccessAt ? { lastSuccessAt: event.lastSuccessAt } : {}),
+    ...(event.lastAckAt ? { lastAckAt: event.lastAckAt } : {}),
     ...(event.lastWakeAt ? { lastWakeAt: event.lastWakeAt } : {}),
     ...(event.retryAt ? { retryAt: event.retryAt } : {}),
     ...(message ? { lastError: { message, at: errorAt } } : {}),
@@ -179,7 +183,7 @@ export function parseResponsiveDeliverySnapshot(value: unknown): ResponsiveDeliv
     target: { agentSessionId, ...(string(row.target.participantId) ? { participantId: string(row.target.participantId) } : {}), ...(string(row.target.roomId) ? { roomId: string(row.target.roomId) } : {}) },
     state: row.state, updatedAt: row.updatedAt, expiresAt: row.expiresAt,
   };
-  for (const key of ["lastSuccessAt", "lastWakeAt", "retryAt"] as const) if (ISO(row[key])) snapshot[key] = row[key];
+  for (const key of ["lastSuccessAt", "lastAckAt", "lastWakeAt", "retryAt"] as const) if (ISO(row[key])) snapshot[key] = row[key];
   if (row.lastError && ISO(row.lastError.at) && typeof row.lastError.message === "string") snapshot.lastError = { message: redactResponsiveDeliveryDiagnostic(row.lastError.message) || "[REDACTED]", at: row.lastError.at };
   const reason = redactResponsiveDeliveryDiagnostic(row.reason); if (reason) snapshot.reason = reason;
   return snapshot;
@@ -215,7 +219,7 @@ function isActiveLive(snapshot: ResponsiveDeliverySnapshot, now: Date, inspectPi
 }
 function result(state: ResponsiveDeliveryState, snapshot?: ResponsiveDeliverySnapshot, now = new Date()): ResponsiveDeliveryResult {
   if (!snapshot) return { state };
-  return { state, updatedAt: snapshot.updatedAt, ...(snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}), ...(snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}), ...(snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}), ...(snapshot.lastError ? { lastError: snapshot.lastError } : {}), ...(snapshot.reason ? { reason: snapshot.reason } : {}), evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...(snapshot.publisher.version ? { version: snapshot.publisher.version } : {}) } };
+  return { state, updatedAt: snapshot.updatedAt, ...(snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}), ...(snapshot.lastAckAt ? { lastAckAt: snapshot.lastAckAt } : {}), ...(snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}), ...(snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}), ...(snapshot.lastError ? { lastError: snapshot.lastError } : {}), ...(snapshot.reason ? { reason: snapshot.reason } : {}), evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...(snapshot.publisher.version ? { version: snapshot.publisher.version } : {}) } };
 }
 
 /** Pure selection: target identity is agentSessionId, never clientInstanceId. */
@@ -320,7 +324,13 @@ export class ResponsiveDeliveryRecorder {
   private latest?: ResponsiveDeliverySnapshot;
   constructor(private readonly options: ResponsiveDeliveryRecorderOptions) { this.target = { ...options.target }; }
   record(state: ResponsiveDeliveryPublishedState, event: ResponsiveDeliveryEvent = {}): ResponsiveDeliverySnapshot {
-    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, event, this.options.now?.() || new Date());
+    const carried = this.latest?.target.agentSessionId === this.target.agentSessionId ? this.latest : undefined;
+    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, {
+      ...event,
+      ...(state === "watching" && !event.lastSuccessAt && carried?.lastSuccessAt ? { lastSuccessAt: carried.lastSuccessAt } : {}),
+      ...(!event.lastAckAt && carried?.lastAckAt ? { lastAckAt: carried.lastAckAt } : {}),
+      ...(state === "watching" && !event.lastWakeAt && carried?.lastWakeAt ? { lastWakeAt: carried.lastWakeAt } : {}),
+    }, this.options.now?.() || new Date());
     this.latest = snapshot; if (this.options.persist && this.options.cwd) writeResponsiveDeliverySnapshot(this.options.cwd, snapshot); return snapshot;
   }
   starting(event?: ResponsiveDeliveryEvent) { return this.record("starting", event); }

--- a/packages/client/test/delivery.test.mjs
+++ b/packages/client/test/delivery.test.mjs
@@ -154,6 +154,133 @@ test("the post-open drain closes the startup drain-to-subscribe race", async () 
   }
 });
 
+test("an empty fetch reports liveness without handling or acknowledgement", async () => {
+  const h = harness({ rooms: { [ALPHA]: [] }, profiles: "alpha" });
+  const progress = [];
+  const controller = new ResponsiveDeliveryController(h.client, {
+    handler: async () => "handled",
+    onProgress: (kind) => progress.push(kind),
+  });
+  try {
+    await h.client.connect();
+    await controller.drainForTest(ALPHA);
+    assert.deepEqual(progress, ["fetch_success"]);
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
+test("progress diagnostics never interrupt delivery", async () => {
+  const h = harness({ rooms: { [ALPHA]: [{ seq: 1, event_id: "diagnostic-failure" }] }, profiles: "alpha" });
+  const controller = new ResponsiveDeliveryController(h.client, {
+    handler: async () => "handled",
+    onProgress: () => { throw new Error("diagnostic unavailable"); },
+  });
+  try {
+    await h.client.connect();
+    await controller.drainForTest(ALPHA);
+    assert.deepEqual(h.acks.map(([, eventId]) => eventId), ["diagnostic-failure"]);
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
+test("handler and acknowledgement failures stop at the last completed stage", async () => {
+  let ackFailures = 1;
+  const h = harness({ rooms: { [ALPHA]: [{ seq: 1, event_id: "stage-row" }] }, profiles: "alpha" });
+  const baseFetch = h.client.fetchImpl;
+  let handlerFails = true;
+  const client = new ParleAgentClient({
+    cwd: h.client.cwd,
+    env: h.client.env,
+    fetch: async (url, init = {}) => {
+      if (new URL(String(url)).pathname.endsWith("/responsive-delivery/ack") && ackFailures-- > 0) {
+        return json({ error: { code: "unavailable", message: "ack unavailable", action: "retry_with_backoff", scope: "request", retryable: true } }, 503);
+      }
+      return baseFetch(url, init);
+    },
+  });
+  const progress = [];
+  const controller = new ResponsiveDeliveryController(client, {
+    handler: async () => {
+      if (handlerFails) throw new Error("handler unavailable");
+      return "handled";
+    },
+    maxDrainBatches: 1,
+    maxHandlerAttempts: 3,
+    onProgress: (kind) => progress.push(kind),
+  });
+  try {
+    await client.connect();
+    await controller.drainForTest(ALPHA);
+    assert.deepEqual(progress, ["fetch_success"], "handler failure emits no later stage");
+
+    handlerFails = false;
+    await controller.drainForTest(ALPHA);
+    assert.deepEqual(progress, ["fetch_success", "fetch_success", "handling_complete"], "ack failure stops after handling");
+
+    await controller.drainForTest(ALPHA);
+    assert.deepEqual(progress, ["fetch_success", "fetch_success", "handling_complete", "fetch_success", "ack_success"], "ack retry never reruns handling");
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
+test("deferred completion reports handling once and acknowledgement after retry", async () => {
+  let ackFailures = 1;
+  const h = harness({ rooms: { [ALPHA]: [{ seq: 1, event_id: "deferred-stage" }] }, profiles: "alpha" });
+  const baseFetch = h.client.fetchImpl;
+  const client = new ParleAgentClient({
+    cwd: h.client.cwd,
+    env: h.client.env,
+    fetch: async (url, init = {}) => {
+      if (new URL(String(url)).pathname.endsWith("/responsive-delivery/ack") && ackFailures-- > 0) {
+        return json({ error: { code: "unavailable", message: "ack unavailable", action: "retry_with_backoff", scope: "request", retryable: true } }, 503);
+      }
+      return baseFetch(url, init);
+    },
+  });
+  const progress = [];
+  let queued;
+  const controller = new ResponsiveDeliveryController(client, {
+    handler: async ({ message }) => { queued = message; return "deferred"; },
+    onProgress: (kind) => progress.push(kind),
+  });
+  try {
+    await client.connect();
+    await controller.drainForTest(ALPHA);
+    assert.equal(progress.includes("handling_complete"), false, "queueing is not effective handling");
+    assert.equal(await controller.completeDeferred(ALPHA, queued), false);
+    assert.equal(await controller.completeDeferred(ALPHA, queued), true);
+    assert.deepEqual(progress.slice(-2), ["handling_complete", "ack_success"], "ack retry does not report host completion twice");
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
+test("poison acknowledgement does not claim successful handling", async () => {
+  const h = harness({ rooms: { [ALPHA]: [{ seq: 1, event_id: "poison-stage" }] }, profiles: "alpha" });
+  const progress = [];
+  const controller = new ResponsiveDeliveryController(h.client, {
+    handler: async () => { throw new Error("poisoned"); },
+    maxHandlerAttempts: 1,
+    onProgress: (kind) => progress.push(kind),
+  });
+  try {
+    await h.client.connect();
+    await controller.drainForTest(ALPHA);
+    assert.equal(progress.includes("handling_complete"), false);
+    assert.equal(progress.includes("ack_success"), true);
+  } finally {
+    await controller.stop();
+    h.cleanup();
+  }
+});
+
 test("a wake hint drains only the named room and acknowledges after handling", async () => {
   const h = harness({ rooms: { [ALPHA]: [{ seq: 1, event_id: "a1" }], [BETA]: [{ seq: 1, event_id: "b1" }] } });
   const handled = [];

--- a/packages/client/test/responsive-delivery.test.mjs
+++ b/packages/client/test/responsive-delivery.test.mjs
@@ -45,6 +45,30 @@ test("responsive recorder normalizes progress leases, recovery, and tombstones",
   assert.equal(resolveResponsiveDelivery([terminal], "agent-a", { now: now(), inspectPid: () => "dead" }).state, "terminal");
 });
 
+test("acknowledgement evidence survives later liveness publications and file round trips", () => {
+  ms = Date.parse("2026-01-01T01:00:00Z");
+  const cwd = mkdtempSync(join(tmpdir(), "parle-responsive-ack-"));
+  try {
+    const recorder = new ResponsiveDeliveryRecorder({ ...base(15), cwd, persist: true, now });
+    const first = recorder.watching({ expectedProgressMs: 570_000, lastSuccessAt: now().toISOString() });
+    ms += 300_000;
+    const ackAt = now().toISOString();
+    recorder.watching({ expectedProgressMs: 570_000, lastAckAt: ackAt });
+    ms += 300_000;
+    const refreshed = recorder.watching({ expectedProgressMs: 570_000, lastSuccessAt: now().toISOString() });
+
+    assert.equal(refreshed.lastAckAt, ackAt, "later fetch liveness retains the acknowledgement clock");
+    assert.ok(Date.parse(refreshed.expiresAt) > Date.parse(first.expiresAt), "repeated empty fetches renew the lease");
+    assert.equal(resolveResponsiveDelivery([refreshed], "agent-a", { now: new Date(Date.parse(first.expiresAt) + 1), inspectPid: live }).state, "watching");
+
+    const [parsed] = readResponsiveDeliverySnapshots(cwd);
+    assert.equal(parsed.lastAckAt, ackAt);
+    assert.equal(resolveResponsiveDelivery([parsed], "agent-a", { now: now(), inspectPid: live }).lastAckAt, ackAt);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("resolver expires wedged active owners and handles PID evidence conservatively", () => {
   ms = Date.parse("2026-01-01T01:00:00Z");
   const snapshot = active();

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.53",
+  "version": "0.6.54",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.53"
+        "PARLE_INTEGRATION_VERSION": "0.6.54"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.54 (2026-08-18)
+
+- Expose additive responsive-delivery acknowledgement evidence while preserving fetch liveness (#157).
+
 ## 0.6.53 (2026-08-18)
 
 - Publish the complete #156 room-recovery diagnostic fix under a unique Codex plugin version.

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -32379,6 +32379,7 @@ function buildResponsiveDeliverySnapshot(base, state, event = {}, now = /* @__PU
     updatedAt,
     expiresAt,
     ...event.lastSuccessAt ? { lastSuccessAt: event.lastSuccessAt } : {},
+    ...event.lastAckAt ? { lastAckAt: event.lastAckAt } : {},
     ...event.lastWakeAt ? { lastWakeAt: event.lastWakeAt } : {},
     ...event.retryAt ? { retryAt: event.retryAt } : {},
     ...message ? { lastError: { message, at: errorAt } } : {},
@@ -32429,7 +32430,7 @@ function parseResponsiveDeliverySnapshot(value) {
     updatedAt: row.updatedAt,
     expiresAt: row.expiresAt
   };
-  for (const key of ["lastSuccessAt", "lastWakeAt", "retryAt"])
+  for (const key of ["lastSuccessAt", "lastAckAt", "lastWakeAt", "retryAt"])
     if (ISO(row[key]))
       snapshot[key] = row[key];
   if (row.lastError && ISO(row.lastError.at) && typeof row.lastError.message === "string")
@@ -32491,7 +32492,7 @@ function isActiveLive(snapshot, now, inspectPid) {
 function result(state, snapshot, now = /* @__PURE__ */ new Date()) {
   if (!snapshot)
     return { state };
-  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
+  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastAckAt ? { lastAckAt: snapshot.lastAckAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
 }
 function resolveResponsiveDelivery(snapshots, agentSessionId, options = {}) {
   const now = options.now || /* @__PURE__ */ new Date();
@@ -32622,7 +32623,13 @@ var ResponsiveDeliveryRecorder = class {
     this.target = { ...options.target };
   }
   record(state, event = {}) {
-    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, event, this.options.now?.() || /* @__PURE__ */ new Date());
+    const carried = this.latest?.target.agentSessionId === this.target.agentSessionId ? this.latest : void 0;
+    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, {
+      ...event,
+      ...state === "watching" && !event.lastSuccessAt && carried?.lastSuccessAt ? { lastSuccessAt: carried.lastSuccessAt } : {},
+      ...!event.lastAckAt && carried?.lastAckAt ? { lastAckAt: carried.lastAckAt } : {},
+      ...state === "watching" && !event.lastWakeAt && carried?.lastWakeAt ? { lastWakeAt: carried.lastWakeAt } : {}
+    }, this.options.now?.() || /* @__PURE__ */ new Date());
     this.latest = snapshot;
     if (this.options.persist && this.options.cwd)
       writeResponsiveDeliverySnapshot(this.options.cwd, snapshot);
@@ -35737,6 +35744,11 @@ var ResponsiveDeliveryController = class {
     if (this.seen.has(key))
       return true;
     const stat = this.stat(roomId);
+    const deferred = this.deferred.get(key);
+    if (deferred && !deferred.completionReported) {
+      deferred.completionReported = true;
+      this.reportProgress("handling_complete");
+    }
     try {
       await this.client.ackResponsiveDelivery(message, this.abort.signal, roomId);
     } catch (error51) {
@@ -35744,6 +35756,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(roomId, "ack");
+    this.reportProgress("ack_success");
     this.deferred.delete(key);
     this.handled.delete(key);
     this.remember(key);
@@ -35966,7 +35979,7 @@ var ResponsiveDeliveryController = class {
       try {
         delivery = await this.client.drainResponsiveDelivery(this.abort.signal, room.roomId);
         this.clearRoomError(room.roomId, "drain");
-        this.reportProgress("drain_success");
+        this.reportProgress("fetch_success");
       } catch (error51) {
         this.setRoomError(room.roomId, "drain", error51);
         return;
@@ -36017,6 +36030,7 @@ var ResponsiveDeliveryController = class {
           this.deferred.set(key, { roomId: room.roomId, message });
           return true;
         }
+        this.reportProgress("handling_complete");
       } catch (error51) {
         const attempts = (this.attempts.get(key) || 0) + 1;
         this.attempts.set(key, attempts);
@@ -36037,6 +36051,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(room.roomId, "ack");
+    this.reportProgress("ack_success");
     this.handled.delete(key);
     this.remember(key);
     if (outcome === "intentionally_skipped")
@@ -38622,7 +38637,15 @@ var HookDeliveryBridge = class {
     this.controller = new ResponsiveDeliveryController(client, {
       handler: (input) => this.handleDelivery(input),
       maxHandlerAttempts: Number.MAX_SAFE_INTEGER,
-      onProgress: () => this.publishEvidence("watching", { expectedProgressMs: 57e4, lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() }),
+      onProgress: (kind) => {
+        const at = (/* @__PURE__ */ new Date()).toISOString();
+        this.publishEvidence("watching", {
+          expectedProgressMs: 57e4,
+          ...["wake_open", "fetch_success"].includes(kind) ? { lastSuccessAt: at } : {},
+          ...kind === "wake_open" ? { lastWakeAt: at } : {},
+          ...kind === "ack_success" ? { lastAckAt: at } : {}
+        });
+      },
       onWakeError: (error51) => {
         const message = error51 instanceof Error ? error51.message : String(error51);
         const action = typeof error51 === "object" && error51 !== null ? error51.action : void 0;
@@ -38732,7 +38755,7 @@ var HookDeliveryBridge = class {
         this.baselineDone = true;
         this.lastError = void 0;
         this.lastErrorKind = void 0;
-        this.publishEvidence("watching", { expectedProgressMs: 57e4, lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() });
+        this.publishEvidence("watching", { expectedProgressMs: 57e4 });
       } catch (error51) {
         this.lastError = error51 instanceof Error ? error51.message : String(error51);
         this.lastErrorKind = "controller";
@@ -39672,7 +39695,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.52";
+var MCP_CLIENT_VERSION = "0.7.53";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.53",
+  "version": "0.6.54",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.30 (2026-08-18)
+
+- Separate delivery-loop liveness from acknowledgement evidence in native responsive delivery (#157).
+
 ## 0.7.29 (2026-08-18)
 
 - Refresh the bundled client with the complete #156 room-recovery diagnostic fix.

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -1386,6 +1386,7 @@ function buildResponsiveDeliverySnapshot(base, state, event = {}, now = /* @__PU
     updatedAt,
     expiresAt,
     ...event.lastSuccessAt ? { lastSuccessAt: event.lastSuccessAt } : {},
+    ...event.lastAckAt ? { lastAckAt: event.lastAckAt } : {},
     ...event.lastWakeAt ? { lastWakeAt: event.lastWakeAt } : {},
     ...event.retryAt ? { retryAt: event.retryAt } : {},
     ...message ? { lastError: { message, at: errorAt } } : {},
@@ -1436,7 +1437,7 @@ function parseResponsiveDeliverySnapshot(value) {
     updatedAt: row.updatedAt,
     expiresAt: row.expiresAt
   };
-  for (const key of ["lastSuccessAt", "lastWakeAt", "retryAt"])
+  for (const key of ["lastSuccessAt", "lastAckAt", "lastWakeAt", "retryAt"])
     if (ISO(row[key]))
       snapshot[key] = row[key];
   if (row.lastError && ISO(row.lastError.at) && typeof row.lastError.message === "string")
@@ -1498,7 +1499,7 @@ function isActiveLive(snapshot, now, inspectPid) {
 function result(state, snapshot, now = /* @__PURE__ */ new Date()) {
   if (!snapshot)
     return { state };
-  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
+  return { state, updatedAt: snapshot.updatedAt, ...snapshot.lastSuccessAt ? { lastSuccessAt: snapshot.lastSuccessAt } : {}, ...snapshot.lastAckAt ? { lastAckAt: snapshot.lastAckAt } : {}, ...snapshot.lastWakeAt ? { lastWakeAt: snapshot.lastWakeAt } : {}, ...snapshot.retryAt ? { retryAt: snapshot.retryAt } : {}, ...snapshot.lastError ? { lastError: snapshot.lastError } : {}, ...snapshot.reason ? { reason: snapshot.reason } : {}, evidenceAgeMs: Math.max(0, now.getTime() - Date.parse(snapshot.updatedAt)), publisher: { name: snapshot.publisher.name, ...snapshot.publisher.version ? { version: snapshot.publisher.version } : {} } };
 }
 function resolveResponsiveDelivery(snapshots, agentSessionId, options = {}) {
   const now = options.now || /* @__PURE__ */ new Date();
@@ -1629,7 +1630,13 @@ var ResponsiveDeliveryRecorder = class {
     this.target = { ...options.target };
   }
   record(state, event = {}) {
-    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, event, this.options.now?.() || /* @__PURE__ */ new Date());
+    const carried = this.latest?.target.agentSessionId === this.target.agentSessionId ? this.latest : void 0;
+    const snapshot = buildResponsiveDeliverySnapshot({ pid: this.options.pid ?? process.pid, processStartedAt: this.options.processStartedAt, publisher: this.options.publisher, target: this.target }, state, {
+      ...event,
+      ...state === "watching" && !event.lastSuccessAt && carried?.lastSuccessAt ? { lastSuccessAt: carried.lastSuccessAt } : {},
+      ...!event.lastAckAt && carried?.lastAckAt ? { lastAckAt: carried.lastAckAt } : {},
+      ...state === "watching" && !event.lastWakeAt && carried?.lastWakeAt ? { lastWakeAt: carried.lastWakeAt } : {}
+    }, this.options.now?.() || /* @__PURE__ */ new Date());
     this.latest = snapshot;
     if (this.options.persist && this.options.cwd)
       writeResponsiveDeliverySnapshot(this.options.cwd, snapshot);
@@ -4744,6 +4751,11 @@ var ResponsiveDeliveryController = class {
     if (this.seen.has(key))
       return true;
     const stat = this.stat(roomId);
+    const deferred = this.deferred.get(key);
+    if (deferred && !deferred.completionReported) {
+      deferred.completionReported = true;
+      this.reportProgress("handling_complete");
+    }
     try {
       await this.client.ackResponsiveDelivery(message, this.abort.signal, roomId);
     } catch (error51) {
@@ -4751,6 +4763,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(roomId, "ack");
+    this.reportProgress("ack_success");
     this.deferred.delete(key);
     this.handled.delete(key);
     this.remember(key);
@@ -4973,7 +4986,7 @@ var ResponsiveDeliveryController = class {
       try {
         delivery = await this.client.drainResponsiveDelivery(this.abort.signal, room.roomId);
         this.clearRoomError(room.roomId, "drain");
-        this.reportProgress("drain_success");
+        this.reportProgress("fetch_success");
       } catch (error51) {
         this.setRoomError(room.roomId, "drain", error51);
         return;
@@ -5024,6 +5037,7 @@ var ResponsiveDeliveryController = class {
           this.deferred.set(key, { roomId: room.roomId, message });
           return true;
         }
+        this.reportProgress("handling_complete");
       } catch (error51) {
         const attempts = (this.attempts.get(key) || 0) + 1;
         this.attempts.set(key, attempts);
@@ -5044,6 +5058,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(room.roomId, "ack");
+    this.reportProgress("ack_success");
     this.handled.delete(key);
     this.remember(key);
     if (outcome === "intentionally_skipped")
@@ -22668,7 +22683,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var ADAPTER_NAME = "@parlehq/command-code-adapter";
-var ADAPTER_VERSION = "0.7.29";
+var ADAPTER_VERSION = "0.7.30";
 var CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 var STATUS_INTERVAL_MS = 5e3;
 var SYSTEM_GUIDANCE = [
@@ -22703,7 +22718,14 @@ var NativeResponsiveDelivery = class {
   createController() {
     return new ResponsiveDeliveryController(this.client, {
       handler: (input) => this.handleDelivery(input),
-      onProgress: () => this.publish("watching", { lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() }),
+      onProgress: (kind) => {
+        const at = (/* @__PURE__ */ new Date()).toISOString();
+        this.publish("watching", {
+          ...["wake_open", "fetch_success"].includes(kind) ? { lastSuccessAt: at } : {},
+          ...kind === "wake_open" ? { lastWakeAt: at } : {},
+          ...kind === "ack_success" ? { lastAckAt: at } : {}
+        });
+      },
       onWakeOpen: () => this.handleWakeOpen(),
       onWakeError: (error51) => this.handleWakeError(error51)
     });
@@ -22714,7 +22736,6 @@ var NativeResponsiveDelivery = class {
   handleWakeOpen() {
     this.lastError = void 0;
     this.terminalAction = void 0;
-    this.publish("watching", { lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() });
     this.refreshStatus();
   }
   // Returning void keeps ordinary wake failures inside the controller's own
@@ -22756,7 +22777,6 @@ var NativeResponsiveDelivery = class {
       }
     });
     this.pending.push({ roomId: input.roomId, message: input.message, projected: appended.message, folded: false });
-    this.publish("watching", { lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() });
     this.refreshStatus();
     return "deferred";
   }
@@ -22828,7 +22848,7 @@ var NativeResponsiveDelivery = class {
     }
     this.lastError = void 0;
     this.terminalAction = void 0;
-    this.publish("watching", { lastSuccessAt: (/* @__PURE__ */ new Date()).toISOString() });
+    this.publish("watching", {});
     this.refreshStatus();
   }
   publish(state, event) {

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/src/index.ts
+++ b/packages/command-code/src/index.ts
@@ -3,7 +3,7 @@ import { registerParleTools, type DegradedMcpBoot, type ParleMcpClientLike, type
 import { z } from "zod";
 
 const ADAPTER_NAME = "@parlehq/command-code-adapter";
-const ADAPTER_VERSION = "0.7.29";
+const ADAPTER_VERSION = "0.7.30";
 const CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 const STATUS_INTERVAL_MS = 5_000;
 
@@ -43,7 +43,14 @@ export class NativeResponsiveDelivery {
   private createController(): ResponsiveDeliveryController {
     return new ResponsiveDeliveryController(this.client, {
       handler: (input) => this.handleDelivery(input),
-      onProgress: () => this.publish("watching", { lastSuccessAt: new Date().toISOString() }),
+      onProgress: (kind) => {
+        const at = new Date().toISOString();
+        this.publish("watching", {
+          ...(["wake_open", "fetch_success"].includes(kind) ? { lastSuccessAt: at } : {}),
+          ...(kind === "wake_open" ? { lastWakeAt: at } : {}),
+          ...(kind === "ack_success" ? { lastAckAt: at } : {}),
+        });
+      },
       onWakeOpen: () => this.handleWakeOpen(),
       onWakeError: (error) => this.handleWakeError(error),
     });
@@ -55,7 +62,6 @@ export class NativeResponsiveDelivery {
   handleWakeOpen(): void {
     this.lastError = undefined;
     this.terminalAction = undefined;
-    this.publish("watching", { lastSuccessAt: new Date().toISOString() });
     this.refreshStatus();
   }
 
@@ -104,7 +110,6 @@ export class NativeResponsiveDelivery {
       },
     });
     this.pending.push({ roomId: input.roomId, message: input.message, projected: appended.message, folded: false });
-    this.publish("watching", { lastSuccessAt: new Date().toISOString() });
     this.refreshStatus();
     return "deferred" as const;
   }
@@ -195,7 +200,7 @@ export class NativeResponsiveDelivery {
     }
     this.lastError = undefined;
     this.terminalAction = undefined;
-    this.publish("watching", { lastSuccessAt: new Date().toISOString() });
+    this.publish("watching", {});
     this.refreshStatus();
   }
 

--- a/packages/command-code/test/index.test.mjs
+++ b/packages/command-code/test/index.test.mjs
@@ -61,7 +61,7 @@ test("root and package manifests expose only the native mod", () => {
   const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
   assert.deepEqual(root.commandcode.mods, ["./packages/command-code/mods/parle.ts"]);
   assert.deepEqual(pkg.commandcode.mods, ["./mods/parle.ts"]);
-  assert.equal(pkg.version, "0.7.29");
+  assert.equal(pkg.version, "0.7.30");
   assert.match(readFileSync(resolve("src/index.ts"), "utf8"), new RegExp(`ADAPTER_VERSION = "${pkg.version}"`));
 
   const artifact = readFileSync(resolve("mods/parle.ts"), "utf8");
@@ -176,6 +176,32 @@ test("session replacement retains deferred work for the replacement turn", async
   const replacement = delivery.foldPending({ messages: [] });
   assert.deepEqual(replacement.messages, [projected]);
   assert.equal(delivery.status().pending, 1);
+});
+
+test("native progress keeps liveness separate from acknowledgement", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "parle-command-code-progress-"));
+  try {
+    const client = { runtime: { agentSessionId: "agent-1" }, clientInstanceId: "test-client" };
+    const delivery = new source.NativeResponsiveDelivery({ cwd, session: { appendCustomMessageEntry() {} } }, client, () => {});
+    const evidencePath = join(cwd, ".parle", "runtime", "responsive", `${process.pid}.json`);
+
+    delivery.controller.onProgress("fetch_success");
+    const fetched = JSON.parse(readFileSync(evidencePath, "utf8"));
+    assert.equal(typeof fetched.lastSuccessAt, "string");
+    assert.equal(fetched.lastAckAt, undefined);
+
+    delivery.controller.onProgress("handling_complete");
+    assert.equal(JSON.parse(readFileSync(evidencePath, "utf8")).lastAckAt, undefined);
+
+    delivery.controller.onProgress("ack_success");
+    const acknowledged = JSON.parse(readFileSync(evidencePath, "utf8"));
+    assert.equal(typeof acknowledged.lastAckAt, "string");
+
+    delivery.controller.onProgress("fetch_success");
+    assert.equal(JSON.parse(readFileSync(evidencePath, "utf8")).lastAckAt, acknowledged.lastAckAt, "later fetches retain the ack clock");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("repeated start preserves persisted success and backoff evidence", async () => {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.53 (2026-08-18)
+
+- Publish acknowledgement-backed `lastAckAt` without mistaking fetch liveness for completed delivery (#157).
+
 ## 0.7.52 (2026-08-18)
 
 - Publish the complete #156 room-recovery diagnostic fix under a unique MCP version.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/hook-delivery-bridge.ts
+++ b/packages/mcp-server/src/hook-delivery-bridge.ts
@@ -268,7 +268,15 @@ export class HookDeliveryBridge {
     this.controller = new ResponsiveDeliveryController(client, {
       handler: (input) => this.handleDelivery(input),
       maxHandlerAttempts: Number.MAX_SAFE_INTEGER,
-      onProgress: () => this.publishEvidence("watching", { expectedProgressMs: 570_000, lastSuccessAt: new Date().toISOString() }),
+      onProgress: (kind) => {
+        const at = new Date().toISOString();
+        this.publishEvidence("watching", {
+          expectedProgressMs: 570_000,
+          ...(["wake_open", "fetch_success"].includes(kind) ? { lastSuccessAt: at } : {}),
+          ...(kind === "wake_open" ? { lastWakeAt: at } : {}),
+          ...(kind === "ack_success" ? { lastAckAt: at } : {}),
+        });
+      },
       onWakeError: (error) => {
         const message = error instanceof Error ? error.message : String(error);
         const action = typeof error === "object" && error !== null ? (error as { action?: string }).action : undefined;
@@ -366,7 +374,7 @@ export class HookDeliveryBridge {
         this.baselineDone = true;
         this.lastError = undefined;
         this.lastErrorKind = undefined;
-        this.publishEvidence("watching", { expectedProgressMs: 570_000, lastSuccessAt: new Date().toISOString() });
+        this.publishEvidence("watching", { expectedProgressMs: 570_000 });
       } catch (error) {
         this.lastError = error instanceof Error ? error.message : String(error);
         this.lastErrorKind = "controller";

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,7 +12,7 @@ import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, 
 export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.52";
+export const MCP_CLIENT_VERSION = "0.7.53";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {

--- a/packages/mcp-server/test/hook-delivery-bridge.test.mjs
+++ b/packages/mcp-server/test/hook-delivery-bridge.test.mjs
@@ -178,6 +178,8 @@ test("hook delivery bridge queues SSE delivery and acks only after lease commit"
     assert.deepEqual(committed, { ok: true, committed: 1 });
     assert.deepEqual(acknowledgements, [[7, "evt-7"]]);
     assert.equal(bridge.status().pending, 0);
+    const evidence = JSON.parse(readFileSync(join(cwd, ".parle", "runtime", "responsive", `${process.pid}.json`), "utf8"));
+    assert.equal(typeof evidence.lastAckAt, "string", "bridge commit publishes acknowledgement evidence");
     await bridge.stop();
     stopped = true;
     assert.equal(existsSync(descriptorPath), false);
@@ -700,6 +702,8 @@ test("hook delivery bridge renews lifecycle evidence on observed progress and to
     await eventually(() => existsSync(evidencePath));
     const opened = JSON.parse(readFileSync(evidencePath, "utf8"));
     assert.equal(opened.state, "watching");
+    assert.equal(typeof opened.lastSuccessAt, "string", "empty fetches publish liveness");
+    assert.equal(opened.lastAckAt, undefined, "empty fetches do not claim acknowledgement");
     void bridge.start();
     const afterStatus = JSON.parse(readFileSync(evidencePath, "utf8"));
     assert.equal(afterStatus.state, "watching", "plain status startup must not clobber healthy evidence");
@@ -708,7 +712,10 @@ test("hook delivery bridge renews lifecycle evidence on observed progress and to
     await settle(5);
     wakeSink.push({ room_id: ROOM });
     await eventually(() => drains >= 3 && JSON.parse(readFileSync(evidencePath, "utf8")).updatedAt !== firstUpdatedAt);
-    assert.equal(JSON.parse(readFileSync(evidencePath, "utf8")).state, "watching");
+    const renewed = JSON.parse(readFileSync(evidencePath, "utf8"));
+    assert.equal(renewed.state, "watching");
+    assert.equal(typeof renewed.lastSuccessAt, "string");
+    assert.equal(renewed.lastAckAt, undefined);
     await bridge.stop();
     assert.equal(JSON.parse(readFileSync(evidencePath, "utf8")).state, "stopped");
   } finally {

--- a/packages/pi-extension/CHANGELOG.md
+++ b/packages/pi-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.53 (2026-08-18)
+
+- Refresh the bundled client with stage-accurate responsive-delivery progress and additive acknowledgement evidence (#157).
+
 ## 0.7.52 (2026-08-18)
 
 - Refresh the bundled client with the complete #156 room-recovery diagnostic fix.

--- a/packages/pi-extension/dist/index.js
+++ b/packages/pi-extension/dist/index.js
@@ -1439,7 +1439,7 @@ function parseResponsiveDeliverySnapshot(value) {
     updatedAt: row.updatedAt,
     expiresAt: row.expiresAt
   };
-  for (const key of ["lastSuccessAt", "lastWakeAt", "retryAt"])
+  for (const key of ["lastSuccessAt", "lastAckAt", "lastWakeAt", "retryAt"])
     if (ISO(row[key]))
       snapshot[key] = row[key];
   if (row.lastError && ISO(row.lastError.at) && typeof row.lastError.message === "string")
@@ -4552,6 +4552,11 @@ var ResponsiveDeliveryController = class {
     if (this.seen.has(key))
       return true;
     const stat = this.stat(roomId);
+    const deferred = this.deferred.get(key);
+    if (deferred && !deferred.completionReported) {
+      deferred.completionReported = true;
+      this.reportProgress("handling_complete");
+    }
     try {
       await this.client.ackResponsiveDelivery(message, this.abort.signal, roomId);
     } catch (error) {
@@ -4559,6 +4564,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(roomId, "ack");
+    this.reportProgress("ack_success");
     this.deferred.delete(key);
     this.handled.delete(key);
     this.remember(key);
@@ -4781,7 +4787,7 @@ var ResponsiveDeliveryController = class {
       try {
         delivery = await this.client.drainResponsiveDelivery(this.abort.signal, room.roomId);
         this.clearRoomError(room.roomId, "drain");
-        this.reportProgress("drain_success");
+        this.reportProgress("fetch_success");
       } catch (error) {
         this.setRoomError(room.roomId, "drain", error);
         return;
@@ -4832,6 +4838,7 @@ var ResponsiveDeliveryController = class {
           this.deferred.set(key, { roomId: room.roomId, message });
           return true;
         }
+        this.reportProgress("handling_complete");
       } catch (error) {
         const attempts = (this.attempts.get(key) || 0) + 1;
         this.attempts.set(key, attempts);
@@ -4852,6 +4859,7 @@ var ResponsiveDeliveryController = class {
       return false;
     }
     this.clearRoomError(room.roomId, "ack");
+    this.reportProgress("ack_success");
     this.handled.delete(key);
     this.remember(key);
     if (outcome === "intentionally_skipped")
@@ -7256,7 +7264,7 @@ var ParleAgentClient = class _ParleAgentClient {
 import { Type } from "typebox";
 var EXTENSION_ID = "25-parle";
 var PI_CLIENT_NAME = "@parlehq/pi-extension";
-var PI_EXTENSION_VERSION = "0.7.52";
+var PI_EXTENSION_VERSION = "0.7.53";
 var PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 var AI_GUIDANCE_URL = "https://ai.parle.sh";
 var API_LLMS_URL = "https://api.parle.sh/llms.txt";

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/pi-extension",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "private": true,
   "type": "module",
   "pi": {

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_BASE, DEFAULT_VERSION, DEFAULT_WAKE_BASE, FENCE_SUFFIX, INB
 import { Type } from "typebox";
 const EXTENSION_ID = "25-parle";
 const PI_CLIENT_NAME = "@parlehq/pi-extension";
-const PI_EXTENSION_VERSION = "0.7.52";
+const PI_EXTENSION_VERSION = "0.7.53";
 const PI_CLIENT_INSTANCE_ID = processClientInstanceId();
 // Snapshot schema v2: one session, rooms[] only. Kept in step with
 // @parlehq/agent-client; readers accept nothing else.

--- a/packages/pi-extension/test/index.test.mjs
+++ b/packages/pi-extension/test/index.test.mjs
@@ -925,7 +925,7 @@ test("status publishes a display-safe runtime snapshot", async () => {
   assert.equal(snapshot.sessionAddress, "@p.a.raw-session");
   assert.deepEqual(snapshot.rooms, [{ roomId: "room-1", roomHandle: "galexc-intercom", participantId: "p-1", state: "ready" }]);
   assert.equal(snapshot.roomId, undefined, "v1 fields are gone in the hard cut");
-  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.52" });
+  assert.deepEqual(snapshot.adapter, { name: "@parlehq/pi-extension", version: "0.7.53" });
   assert.equal(JSON.stringify(snapshot).includes("parle_ses_raw-session"), false);
 });
 
@@ -1611,7 +1611,7 @@ test("Pi JSON, generic agent request, and wake use one protected process identit
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.headers["Parle-Client-Name"], "@parlehq/pi-extension");
-    assert.equal(call.headers["Parle-Client-Version"], "0.7.52");
+    assert.equal(call.headers["Parle-Client-Version"], "0.7.53");
     assert.equal(call.headers["Parle-Client-Instance"], __testing.clientInstanceId);
   }
   assert.equal(calls[1].headers["X-Test"], "safe");


### PR DESCRIPTION
## Summary

- distinguish wake, fetch, handling, and acknowledgement progress in the shared controller
- preserve delivery-loop liveness in `lastSuccessAt` and publish additive schema-v1 `lastAckAt` only after successful acknowledgement
- update MCP and Command Code publishers, generated artifacts, package versions, changelogs, and canonical topology docs

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test` except Codex Unix-socket fixtures blocked by the local sandbox (`listen EPERM` also reproduces with a minimal `/tmp` socket)
- `pnpm -F @parlehq/claude-plugin test`
- focused client, MCP bridge, and Command Code tests
- `pnpm check:mcp-artifacts`
- `pnpm check:manifests`
- `pnpm check:release-claims`

Closes #157