### PR TITLE
codex-plugin: forward profile selectors and resolve the project .env from PWD (#169)

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8.59 (2026-08-27)
 
-- Carry the launch-directory configuration resolution of MCP server 0.7.59 through the refreshed MCP artifact (#169).
+- Refresh the bundled MCP artifact to server 0.7.59, which carries opt-in launch-directory configuration; this host does not enable it, so configuration resolution is unchanged (#169).
 
 ## 0.8.58 (2026-08-31)
 

--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.59 (2026-08-27)
+
+- Carry the launch-directory configuration resolution of MCP server 0.7.59 through the refreshed MCP artifact (#169).
+
 ## 0.8.58 (2026-08-31)
 
 - Refresh the bundled MCP runtime with fallback deadline and stage evidence from the shared responsive-delivery controller (#80).

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.58",
+  "version": "0.8.59",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.58"
+        "PARLE_INTEGRATION_VERSION": "0.8.59"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.58",
+  "version": "0.8.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -39606,7 +39606,14 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: true }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    if (degradedBoot) return { ...degradedConfigDiagnostic(degradedBoot.error), bootstrapAttempted: false };
+    if (degradedBoot) {
+      return {
+        ...degradedConfigDiagnostic(degradedBoot.error),
+        configCwd: degradedBoot.cwd || process.cwd(),
+        configCwdSource: degradedBoot.cwdSource || "process.cwd",
+        bootstrapAttempted: false
+      };
+    }
     let bootstrapAttempted = false;
     if (!params.inspect && typeof client.ensureReadySafe === "function") bootstrapAttempted = await client.ensureReadySafe();
     if (!params.inspect && deliveryBridge?.start) void deliveryBridge.start().catch(() => void 0);
@@ -40105,7 +40112,7 @@ function resolveIntegrationMetadata(env = process.env) {
 }
 function resolveConfigCwd(env = process.env, fallback = process.cwd()) {
   const pwd = env.PWD;
-  if (pwd && isAbsolute4(pwd)) {
+  if (env.PARLE_CONFIG_CWD_FROM_PWD === "1" && pwd && isAbsolute4(pwd)) {
     try {
       const resolved = realpathSync2(pwd);
       if (statSync4(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
@@ -40199,6 +40206,7 @@ async function runStdio() {
   const server = runtime ? createParleMcpServer(runtime.client, runtime.accountClient, runtime.deliveryBridge) : createParleMcpServer({}, new ParleAccountClient(), void 0, {
     error: configError,
     cwd: configCwd.cwd,
+    cwdSource: configCwd.source,
     env: process.env,
     recover: createRuntime,
     onRecovered(recovered) {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -30953,9 +30953,9 @@ var StdioServerTransport = class {
 };
 
 // src/index.ts
-import { lstatSync as lstatSync8, readFileSync as readFileSync6, readdirSync as readdirSync4 } from "node:fs";
+import { lstatSync as lstatSync8, readFileSync as readFileSync6, readdirSync as readdirSync4, realpathSync as realpathSync2, statSync as statSync4 } from "node:fs";
 import { connect } from "node:net";
-import { join as join11 } from "node:path";
+import { isAbsolute as isAbsolute4, join as join11 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // ../client/dist/index.js
@@ -39684,7 +39684,7 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    const path = resolveSavedStartCatalogPath(process.cwd(), process.env);
+    const path = resolveSavedStartCatalogPath(client.cwd || process.cwd(), process.env);
     if (params.action === "list") {
       return { savedStarts: [...readSavedStarts(path).values()] };
     }
@@ -40092,7 +40092,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.58";
+var MCP_CLIENT_VERSION = "0.7.59";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;
@@ -40102,6 +40102,17 @@ function resolveIntegrationMetadata(env = process.env) {
     integrationName: rawName ? assertClientName(rawName) : void 0,
     integrationVersion: rawVersion ? assertClientVersion(rawVersion) : void 0
   };
+}
+function resolveConfigCwd(env = process.env, fallback = process.cwd()) {
+  const pwd = env.PWD;
+  if (pwd && isAbsolute4(pwd)) {
+    try {
+      const resolved = realpathSync2(pwd);
+      if (statSync4(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
+    } catch {
+    }
+  }
+  return { cwd: fallback, source: "process.cwd" };
 }
 function createMcpAgentClient(options = {}) {
   return new ParleAgentClient({
@@ -40135,11 +40146,12 @@ async function runStdio() {
     throw new Error(`Unsupported PARLE_HOOK_BRIDGE_HOST_PROCESS mode: ${hostProcessMode}`);
   }
   const hostParentPid = hostProcessMode === "direct-parent" ? process.ppid : void 0;
+  const configCwd = resolveConfigCwd();
   let stopPreRuntimeParentCheck = hostParentPid === void 0 ? () => {
   } : scheduleHostParentCheck(hostParentPid, () => process.exit(0));
   const createRuntime = () => {
     const clientEnv = hookBridgeEnabled ? { ...process.env, PARLE_UNREAD_POLL_INTERVAL_SECONDS: "0" } : process.env;
-    const client = createMcpAgentClient({ env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
+    const client = createMcpAgentClient({ cwd: configCwd.cwd, env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
     if (hookBridgeEnabled) {
       client.switchProfile = async () => {
         throw new Error("Live Parle profile switching is unavailable while the hook bridge owns responsive delivery. Restart the host with the target PARLE_PROFILE so the MCP session, wake stream, queue, and hook binding change atomically.");
@@ -40152,11 +40164,14 @@ async function runStdio() {
       process.cwd(),
       hostParentPid
     ) : void 0;
-    if (deliveryBridge) {
-      const baseStatus = client.status.bind(client);
-      client.status = () => ({ ...baseStatus(), responsiveDeliveryBridge: deliveryBridge.status() });
-    }
-    return { client, accountClient: new ParleAccountClient(), deliveryBridge };
+    const baseStatus = client.status.bind(client);
+    client.status = () => ({
+      ...baseStatus(),
+      configCwd: configCwd.cwd,
+      configCwdSource: configCwd.source,
+      ...deliveryBridge ? { responsiveDeliveryBridge: deliveryBridge.status() } : {}
+    });
+    return { client, accountClient: new ParleAccountClient({ cwd: configCwd.cwd }), deliveryBridge };
   };
   let activated = false;
   const activateRuntime = (runtime2) => {
@@ -40183,7 +40198,7 @@ async function runStdio() {
   }
   const server = runtime ? createParleMcpServer(runtime.client, runtime.accountClient, runtime.deliveryBridge) : createParleMcpServer({}, new ParleAccountClient(), void 0, {
     error: configError,
-    cwd: process.cwd(),
+    cwd: configCwd.cwd,
     env: process.env,
     recover: createRuntime,
     onRecovered(recovered) {
@@ -40441,6 +40456,7 @@ export {
   isDirectRun,
   parseWatcherArgs,
   registerParleTools,
+  resolveConfigCwd,
   resolveIntegrationMetadata,
   runStdio,
   runWatcher,

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.63",
+  "version": "0.9.64",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -9,7 +9,7 @@
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.63"
+        "PARLE_INTEGRATION_VERSION": "0.9.64"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.9.64 (2026-08-27)
 
-- Carry the launch-directory configuration resolution of MCP server 0.7.59 through the refreshed MCP artifact (#169).
+- Refresh the bundled MCP artifact to server 0.7.59, which carries opt-in launch-directory configuration; this host does not enable it, so configuration resolution is unchanged (#169).
 
 ## 0.9.63 (2026-08-31)
 

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.64 (2026-08-27)
+
+- Carry the launch-directory configuration resolution of MCP server 0.7.59 through the refreshed MCP artifact (#169).
+
 ## 0.9.63 (2026-08-31)
 
 - Refresh the bundled MCP runtime with fallback deadline and stage evidence from the shared responsive-delivery controller (#80).

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -39606,7 +39606,14 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: true }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    if (degradedBoot) return { ...degradedConfigDiagnostic(degradedBoot.error), bootstrapAttempted: false };
+    if (degradedBoot) {
+      return {
+        ...degradedConfigDiagnostic(degradedBoot.error),
+        configCwd: degradedBoot.cwd || process.cwd(),
+        configCwdSource: degradedBoot.cwdSource || "process.cwd",
+        bootstrapAttempted: false
+      };
+    }
     let bootstrapAttempted = false;
     if (!params.inspect && typeof client.ensureReadySafe === "function") bootstrapAttempted = await client.ensureReadySafe();
     if (!params.inspect && deliveryBridge?.start) void deliveryBridge.start().catch(() => void 0);
@@ -40105,7 +40112,7 @@ function resolveIntegrationMetadata(env = process.env) {
 }
 function resolveConfigCwd(env = process.env, fallback = process.cwd()) {
   const pwd = env.PWD;
-  if (pwd && isAbsolute4(pwd)) {
+  if (env.PARLE_CONFIG_CWD_FROM_PWD === "1" && pwd && isAbsolute4(pwd)) {
     try {
       const resolved = realpathSync2(pwd);
       if (statSync4(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
@@ -40199,6 +40206,7 @@ async function runStdio() {
   const server = runtime ? createParleMcpServer(runtime.client, runtime.accountClient, runtime.deliveryBridge) : createParleMcpServer({}, new ParleAccountClient(), void 0, {
     error: configError,
     cwd: configCwd.cwd,
+    cwdSource: configCwd.source,
     env: process.env,
     recover: createRuntime,
     onRecovered(recovered) {

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -30953,9 +30953,9 @@ var StdioServerTransport = class {
 };
 
 // src/index.ts
-import { lstatSync as lstatSync8, readFileSync as readFileSync6, readdirSync as readdirSync4 } from "node:fs";
+import { lstatSync as lstatSync8, readFileSync as readFileSync6, readdirSync as readdirSync4, realpathSync as realpathSync2, statSync as statSync4 } from "node:fs";
 import { connect } from "node:net";
-import { join as join11 } from "node:path";
+import { isAbsolute as isAbsolute4, join as join11 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // ../client/dist/index.js
@@ -39684,7 +39684,7 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    const path = resolveSavedStartCatalogPath(process.cwd(), process.env);
+    const path = resolveSavedStartCatalogPath(client.cwd || process.cwd(), process.env);
     if (params.action === "list") {
       return { savedStarts: [...readSavedStarts(path).values()] };
     }
@@ -40092,7 +40092,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.58";
+var MCP_CLIENT_VERSION = "0.7.59";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;
@@ -40102,6 +40102,17 @@ function resolveIntegrationMetadata(env = process.env) {
     integrationName: rawName ? assertClientName(rawName) : void 0,
     integrationVersion: rawVersion ? assertClientVersion(rawVersion) : void 0
   };
+}
+function resolveConfigCwd(env = process.env, fallback = process.cwd()) {
+  const pwd = env.PWD;
+  if (pwd && isAbsolute4(pwd)) {
+    try {
+      const resolved = realpathSync2(pwd);
+      if (statSync4(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
+    } catch {
+    }
+  }
+  return { cwd: fallback, source: "process.cwd" };
 }
 function createMcpAgentClient(options = {}) {
   return new ParleAgentClient({
@@ -40135,11 +40146,12 @@ async function runStdio() {
     throw new Error(`Unsupported PARLE_HOOK_BRIDGE_HOST_PROCESS mode: ${hostProcessMode}`);
   }
   const hostParentPid = hostProcessMode === "direct-parent" ? process.ppid : void 0;
+  const configCwd = resolveConfigCwd();
   let stopPreRuntimeParentCheck = hostParentPid === void 0 ? () => {
   } : scheduleHostParentCheck(hostParentPid, () => process.exit(0));
   const createRuntime = () => {
     const clientEnv = hookBridgeEnabled ? { ...process.env, PARLE_UNREAD_POLL_INTERVAL_SECONDS: "0" } : process.env;
-    const client = createMcpAgentClient({ env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
+    const client = createMcpAgentClient({ cwd: configCwd.cwd, env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
     if (hookBridgeEnabled) {
       client.switchProfile = async () => {
         throw new Error("Live Parle profile switching is unavailable while the hook bridge owns responsive delivery. Restart the host with the target PARLE_PROFILE so the MCP session, wake stream, queue, and hook binding change atomically.");
@@ -40152,11 +40164,14 @@ async function runStdio() {
       process.cwd(),
       hostParentPid
     ) : void 0;
-    if (deliveryBridge) {
-      const baseStatus = client.status.bind(client);
-      client.status = () => ({ ...baseStatus(), responsiveDeliveryBridge: deliveryBridge.status() });
-    }
-    return { client, accountClient: new ParleAccountClient(), deliveryBridge };
+    const baseStatus = client.status.bind(client);
+    client.status = () => ({
+      ...baseStatus(),
+      configCwd: configCwd.cwd,
+      configCwdSource: configCwd.source,
+      ...deliveryBridge ? { responsiveDeliveryBridge: deliveryBridge.status() } : {}
+    });
+    return { client, accountClient: new ParleAccountClient({ cwd: configCwd.cwd }), deliveryBridge };
   };
   let activated = false;
   const activateRuntime = (runtime2) => {
@@ -40183,7 +40198,7 @@ async function runStdio() {
   }
   const server = runtime ? createParleMcpServer(runtime.client, runtime.accountClient, runtime.deliveryBridge) : createParleMcpServer({}, new ParleAccountClient(), void 0, {
     error: configError,
-    cwd: process.cwd(),
+    cwd: configCwd.cwd,
     env: process.env,
     recover: createRuntime,
     onRecovered(recovered) {
@@ -40441,6 +40456,7 @@ export {
   isDirectRun,
   parseWatcherArgs,
   registerParleTools,
+  resolveConfigCwd,
   resolveIntegrationMetadata,
   runStdio,
   runWatcher,

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.63",
+  "version": "0.9.64",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.59",
+  "version": "0.6.60",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -6,11 +6,18 @@
         "./dist/parle-mcp.js"
       ],
       "cwd": ".",
+      "env_vars": [
+        "PARLE_PROFILE",
+        "PARLE_PROFILES",
+        "PARLE_PROFILES_PATH",
+        "PWD",
+        "CODEX_HOME"
+      ],
       "env": {
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.59"
+        "PARLE_INTEGRATION_VERSION": "0.6.60"
       }
     }
   }

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -14,6 +14,7 @@
         "CODEX_HOME"
       ],
       "env": {
+        "PARLE_CONFIG_CWD_FROM_PWD": "1",
         "PARLE_RESPONSIVE_DELIVERY": "hook-bridge",
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.60 (2026-08-27)
+
+- Forward `PARLE_PROFILE`, `PARLE_PROFILES`, `PARLE_PROFILES_PATH`, `PWD`, and `CODEX_HOME` through Codex's cleared MCP environment and resolve the project `.env` from the shell launch directory instead of the plugin cache (#169).
+
 ## 0.6.59 (2026-08-31)
 
 - Refresh the bundled MCP runtime with fallback deadline and stage evidence from the shared responsive-delivery controller (#80).

--- a/packages/codex-plugin/README.md
+++ b/packages/codex-plugin/README.md
@@ -34,7 +34,7 @@ Codex should discover the Parle skill and MCP tools, call `parle_connect`, then 
 
 ## Profile selection per project
 
-Codex starts plugin MCP servers with a cleared environment and the plugin cache directory as the working directory. The plugin manifest forwards `PARLE_PROFILE`, `PARLE_PROFILES`, `PARLE_PROFILES_PATH`, `PWD`, and `CODEX_HOME` from the launching shell; every other variable is dropped. The server resolves project configuration, including a project `.env`, from `PWD`, the directory the shell was in when `codex` started. Credential variables are never forwarded; credentials stay in `~/.parle/profiles`.
+Codex starts plugin MCP servers with a cleared environment and the plugin cache directory as the working directory. The child receives Codex's default variables (`HOME`, `PATH`, `USER`, `TMPDIR`, `LANG`, `LC_ALL`, `TERM`, `TZ`, `SHELL`, `LOGNAME`), the plugin manifest's literal values, and, forwarded from the launching shell, `PARLE_PROFILE`, `PARLE_PROFILES`, `PARLE_PROFILES_PATH`, `PWD`, and `CODEX_HOME`. Nothing else from the shell reaches the server. The manifest's literal `PARLE_CONFIG_CWD_FROM_PWD=1` opts this host into resolving project configuration, including a project `.env`, from `PWD`, the directory the shell was in when `codex` started. This recipe forwards no Parle credential variables; keep credentials in `~/.parle/profiles` and select them by name. The resolver can also read direct credentials from a project `.env`, but the recipe below does not rely on that.
 
 Pin a profile to a project with a directory-scoped environment. In `.mise.toml`:
 
@@ -52,6 +52,8 @@ export PARLE_PROFILE=codex
 Run `mise trust` or `direnv allow` once, then launch `codex` from the project directory. A project `.env` containing `PARLE_PROFILE=codex` also works because the server reads it from the launch directory; a value in the process environment wins over `.env`. `parle_status` reports `configCwd` and `configCwdSource` (`PWD` or `process.cwd`) so the directory that was used is visible.
 
 `PWD` means the shell launch directory. `codex -C elsewhere` changes the session working directory without changing `PWD`, so it does not select that directory's Parle configuration.
+
+Because the server now treats the launch directory as its configuration directory, credential-free runtime snapshots appear under `<project>/.parle/runtime/` (see [`docs/design/storage-layout.md`](../../docs/design/storage-layout.md)), as they already do for other hosts. Add `.parle/runtime/` to the project `.gitignore`.
 
 Avoid these alternatives:
 

--- a/packages/codex-plugin/README.md
+++ b/packages/codex-plugin/README.md
@@ -24,13 +24,41 @@ codex plugin list
 codex mcp get parle
 ```
 
-The MCP server resolves `~/.parle/profiles` directly. The accepted rationale is recorded in [`docs/design/storage-layout.md`](../../docs/design/storage-layout.md). If the catalog has a `[default]` profile, no extra environment configuration is needed. Otherwise launch Codex with `PARLE_PROFILE` naming the intended profile.
+The MCP server resolves `~/.parle/profiles` directly. The accepted rationale is recorded in [`docs/design/storage-layout.md`](../../docs/design/storage-layout.md). If the catalog has a `[default]` profile, no extra environment configuration is needed. Otherwise select the profile per project as described in [Profile selection per project](#profile-selection-per-project); an exported `PARLE_PROFILE` reaches the server only because the plugin manifest forwards it through Codex's cleared MCP environment.
 
 A normal prompt can then be concise:
 
 > We use ai.parle.sh. Connect to our room and acknowledge `@principal.agent.session` when complete.
 
 Codex should discover the Parle skill and MCP tools, call `parle_connect`, then send the acknowledgement with structured direct addressing. It should not inspect the profile catalog or construct HTTP requests in shell commands.
+
+## Profile selection per project
+
+Codex starts plugin MCP servers with a cleared environment and the plugin cache directory as the working directory. The plugin manifest forwards `PARLE_PROFILE`, `PARLE_PROFILES`, `PARLE_PROFILES_PATH`, `PWD`, and `CODEX_HOME` from the launching shell; every other variable is dropped. The server resolves project configuration, including a project `.env`, from `PWD`, the directory the shell was in when `codex` started. Credential variables are never forwarded; credentials stay in `~/.parle/profiles`.
+
+Pin a profile to a project with a directory-scoped environment. In `.mise.toml`:
+
+```toml
+[env]
+PARLE_PROFILE = "codex"
+```
+
+or in `.envrc`:
+
+```bash
+export PARLE_PROFILE=codex
+```
+
+Run `mise trust` or `direnv allow` once, then launch `codex` from the project directory. A project `.env` containing `PARLE_PROFILE=codex` also works because the server reads it from the launch directory; a value in the process environment wins over `.env`. `parle_status` reports `configCwd` and `configCwdSource` (`PWD` or `process.cwd`) so the directory that was used is visible.
+
+`PWD` means the shell launch directory. `codex -C elsewhere` changes the session working directory without changing `PWD`, so it does not select that directory's Parle configuration.
+
+Avoid these alternatives:
+
+- A project-specific `CODEX_HOME`: it splits Codex state, plugin installs, and trust decisions per project.
+- Editing the plugin cache: the next plugin update overwrites it.
+- A same-name `[mcp_servers.parle]` entry in the project `.codex/config.toml`: it replaces the plugin registration wholesale and pins the install path.
+- `codex --profile`: it selects a Codex configuration profile, not a Parle profile.
 
 ## Responsive delivery
 

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -39606,7 +39606,14 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: true }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    if (degradedBoot) return { ...degradedConfigDiagnostic(degradedBoot.error), bootstrapAttempted: false };
+    if (degradedBoot) {
+      return {
+        ...degradedConfigDiagnostic(degradedBoot.error),
+        configCwd: degradedBoot.cwd || process.cwd(),
+        configCwdSource: degradedBoot.cwdSource || "process.cwd",
+        bootstrapAttempted: false
+      };
+    }
     let bootstrapAttempted = false;
     if (!params.inspect && typeof client.ensureReadySafe === "function") bootstrapAttempted = await client.ensureReadySafe();
     if (!params.inspect && deliveryBridge?.start) void deliveryBridge.start().catch(() => void 0);
@@ -40105,7 +40112,7 @@ function resolveIntegrationMetadata(env = process.env) {
 }
 function resolveConfigCwd(env = process.env, fallback = process.cwd()) {
   const pwd = env.PWD;
-  if (pwd && isAbsolute4(pwd)) {
+  if (env.PARLE_CONFIG_CWD_FROM_PWD === "1" && pwd && isAbsolute4(pwd)) {
     try {
       const resolved = realpathSync2(pwd);
       if (statSync4(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
@@ -40199,6 +40206,7 @@ async function runStdio() {
   const server = runtime ? createParleMcpServer(runtime.client, runtime.accountClient, runtime.deliveryBridge) : createParleMcpServer({}, new ParleAccountClient(), void 0, {
     error: configError,
     cwd: configCwd.cwd,
+    cwdSource: configCwd.source,
     env: process.env,
     recover: createRuntime,
     onRecovered(recovered) {

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -30953,9 +30953,9 @@ var StdioServerTransport = class {
 };
 
 // src/index.ts
-import { lstatSync as lstatSync8, readFileSync as readFileSync6, readdirSync as readdirSync4 } from "node:fs";
+import { lstatSync as lstatSync8, readFileSync as readFileSync6, readdirSync as readdirSync4, realpathSync as realpathSync2, statSync as statSync4 } from "node:fs";
 import { connect } from "node:net";
-import { join as join11 } from "node:path";
+import { isAbsolute as isAbsolute4, join as join11 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // ../client/dist/index.js
@@ -39684,7 +39684,7 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    const path = resolveSavedStartCatalogPath(process.cwd(), process.env);
+    const path = resolveSavedStartCatalogPath(client.cwd || process.cwd(), process.env);
     if (params.action === "list") {
       return { savedStarts: [...readSavedStarts(path).values()] };
     }
@@ -40092,7 +40092,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.58";
+var MCP_CLIENT_VERSION = "0.7.59";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;
@@ -40102,6 +40102,17 @@ function resolveIntegrationMetadata(env = process.env) {
     integrationName: rawName ? assertClientName(rawName) : void 0,
     integrationVersion: rawVersion ? assertClientVersion(rawVersion) : void 0
   };
+}
+function resolveConfigCwd(env = process.env, fallback = process.cwd()) {
+  const pwd = env.PWD;
+  if (pwd && isAbsolute4(pwd)) {
+    try {
+      const resolved = realpathSync2(pwd);
+      if (statSync4(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
+    } catch {
+    }
+  }
+  return { cwd: fallback, source: "process.cwd" };
 }
 function createMcpAgentClient(options = {}) {
   return new ParleAgentClient({
@@ -40135,11 +40146,12 @@ async function runStdio() {
     throw new Error(`Unsupported PARLE_HOOK_BRIDGE_HOST_PROCESS mode: ${hostProcessMode}`);
   }
   const hostParentPid = hostProcessMode === "direct-parent" ? process.ppid : void 0;
+  const configCwd = resolveConfigCwd();
   let stopPreRuntimeParentCheck = hostParentPid === void 0 ? () => {
   } : scheduleHostParentCheck(hostParentPid, () => process.exit(0));
   const createRuntime = () => {
     const clientEnv = hookBridgeEnabled ? { ...process.env, PARLE_UNREAD_POLL_INTERVAL_SECONDS: "0" } : process.env;
-    const client = createMcpAgentClient({ env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
+    const client = createMcpAgentClient({ cwd: configCwd.cwd, env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
     if (hookBridgeEnabled) {
       client.switchProfile = async () => {
         throw new Error("Live Parle profile switching is unavailable while the hook bridge owns responsive delivery. Restart the host with the target PARLE_PROFILE so the MCP session, wake stream, queue, and hook binding change atomically.");
@@ -40152,11 +40164,14 @@ async function runStdio() {
       process.cwd(),
       hostParentPid
     ) : void 0;
-    if (deliveryBridge) {
-      const baseStatus = client.status.bind(client);
-      client.status = () => ({ ...baseStatus(), responsiveDeliveryBridge: deliveryBridge.status() });
-    }
-    return { client, accountClient: new ParleAccountClient(), deliveryBridge };
+    const baseStatus = client.status.bind(client);
+    client.status = () => ({
+      ...baseStatus(),
+      configCwd: configCwd.cwd,
+      configCwdSource: configCwd.source,
+      ...deliveryBridge ? { responsiveDeliveryBridge: deliveryBridge.status() } : {}
+    });
+    return { client, accountClient: new ParleAccountClient({ cwd: configCwd.cwd }), deliveryBridge };
   };
   let activated = false;
   const activateRuntime = (runtime2) => {
@@ -40183,7 +40198,7 @@ async function runStdio() {
   }
   const server = runtime ? createParleMcpServer(runtime.client, runtime.accountClient, runtime.deliveryBridge) : createParleMcpServer({}, new ParleAccountClient(), void 0, {
     error: configError,
-    cwd: process.cwd(),
+    cwd: configCwd.cwd,
     env: process.env,
     recover: createRuntime,
     onRecovered(recovered) {
@@ -40441,6 +40456,7 @@ export {
   isDirectRun,
   parseWatcherArgs,
   registerParleTools,
+  resolveConfigCwd,
   resolveIntegrationMetadata,
   runStdio,
   runWatcher,

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.59",
+  "version": "0.6.60",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/codex-plugin/test/index.test.mjs
+++ b/packages/codex-plugin/test/index.test.mjs
@@ -23,6 +23,7 @@ test("Codex plugin metadata and MCP config point at the bundled server", () => {
   assert.equal(mcp.mcpServers.parle.cwd, ".");
   assert.deepEqual(mcp.mcpServers.parle.env_vars, ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME"]);
   assert.deepEqual(mcp.mcpServers.parle.env, {
+    PARLE_CONFIG_CWD_FROM_PWD: "1",
     PARLE_RESPONSIVE_DELIVERY: "hook-bridge",
     PARLE_HOOK_BRIDGE_SCOPE: "codex-plugin",
     PARLE_INTEGRATION_NAME: "@parlehq/codex-plugin",
@@ -57,6 +58,8 @@ test("Codex MCP config forwards only non-credential selectors from the launching
     assert.doesNotMatch(value, /parle_agt_|parle_hum_/);
   }
   assert.equal(server.env_vars.includes("PWD"), true, "PWD names the shell launch directory for project .env resolution");
+  assert.equal(server.env.PARLE_CONFIG_CWD_FROM_PWD, "1", "only this manifest opts the shared server into PWD-based configuration");
+  assert.equal(server.env_vars.includes("PARLE_CONFIG_CWD_FROM_PWD"), false, "the opt-in is a literal value, never forwarded from the shell");
   assert.equal(server.env_vars.includes("CODEX_HOME"), true, "a later codex subprocess must target the parent's state store");
   assert.equal(server.env_vars.includes("PARLE_ROOM_AGENT_TOKEN"), false);
 });

--- a/packages/codex-plugin/test/index.test.mjs
+++ b/packages/codex-plugin/test/index.test.mjs
@@ -21,6 +21,7 @@ test("Codex plugin metadata and MCP config point at the bundled server", () => {
   assert.equal(mcp.mcpServers.parle.command, "node");
   assert.deepEqual(mcp.mcpServers.parle.args, ["./dist/parle-mcp.js"]);
   assert.equal(mcp.mcpServers.parle.cwd, ".");
+  assert.deepEqual(mcp.mcpServers.parle.env_vars, ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME"]);
   assert.deepEqual(mcp.mcpServers.parle.env, {
     PARLE_RESPONSIVE_DELIVERY: "hook-bridge",
     PARLE_HOOK_BRIDGE_SCOPE: "codex-plugin",
@@ -35,6 +36,29 @@ test("Codex plugin metadata and MCP config point at the bundled server", () => {
     assert.equal(definitions[0].hooks[0].command, `\"\${PLUGIN_ROOT}/hooks/run-parle-hook.sh\" --scope codex-plugin${suffix} || printf '{}\\n'`);
     assert.equal(definitions[0].hooks[0].commandWindows, `cmd /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\run-parle-hook.cmd\" --scope codex-plugin${suffix} || echo {}\"`);
   }
+});
+
+test("Codex MCP config forwards only non-credential selectors from the launching shell", () => {
+  // Codex spawns plugin MCP servers with env_clear(): only its default
+  // variables, the env_vars names, and the literal env map reach the child.
+  // The forwarded names are plain strings that select configuration; the
+  // credentials they select stay in the profile catalog.
+  const mcp = JSON.parse(readFileSync(resolve(root, ".mcp.json"), "utf8"));
+  const server = mcp.mcpServers.parle;
+  assert.equal(server.cwd, ".", "a relative artifact path must stay upgrade-safe");
+  const credentialShape = /TOKEN|SECRET|PASSWORD|CREDENTIAL|_KEY\b|SESSION/i;
+  for (const name of server.env_vars) {
+    assert.equal(typeof name, "string");
+    assert.match(name, /^[A-Z][A-Z0-9_]*$/);
+    assert.doesNotMatch(name, credentialShape);
+  }
+  for (const [name, value] of Object.entries(server.env)) {
+    assert.doesNotMatch(name, credentialShape);
+    assert.doesNotMatch(value, /parle_agt_|parle_hum_/);
+  }
+  assert.equal(server.env_vars.includes("PWD"), true, "PWD names the shell launch directory for project .env resolution");
+  assert.equal(server.env_vars.includes("CODEX_HOME"), true, "a later codex subprocess must target the parent's state store");
+  assert.equal(server.env_vars.includes("PARLE_ROOM_AGENT_TOKEN"), false);
 });
 
 test("Codex Windows launcher discovers only trusted absolute runtimes and fails open", () => {

--- a/packages/command-code/CHANGELOG.md
+++ b/packages/command-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.36 (2026-08-27)
+
+- Resolve the saved-start catalog from the client's configuration directory instead of the process directory, carrying the shared tool-runtime change of MCP server 0.7.59 (#169).
+
 ## 0.7.35 (2026-08-31)
 
 - Refresh the native mod with fallback deadline and stage evidence from the shared responsive-delivery controller (#80).

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -22626,7 +22626,7 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    const path = resolveSavedStartCatalogPath(process.cwd(), process.env);
+    const path = resolveSavedStartCatalogPath(client.cwd || process.cwd(), process.env);
     if (params.action === "list") {
       return { savedStarts: [...readSavedStarts(path).values()] };
     }
@@ -23050,7 +23050,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var ADAPTER_NAME = "@parlehq/command-code-adapter";
-var ADAPTER_VERSION = "0.7.35";
+var ADAPTER_VERSION = "0.7.36";
 var CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 var STATUS_INTERVAL_MS = 5e3;
 var SYSTEM_GUIDANCE = [

--- a/packages/command-code/mods/parle.ts
+++ b/packages/command-code/mods/parle.ts
@@ -22541,8 +22541,14 @@ function registerParleTools(registerTool, client, accountClient = new ParleAccou
     annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: true }
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    if (degradedBoot)
-      return { ...degradedConfigDiagnostic(degradedBoot.error), bootstrapAttempted: false };
+    if (degradedBoot) {
+      return {
+        ...degradedConfigDiagnostic(degradedBoot.error),
+        configCwd: degradedBoot.cwd || process.cwd(),
+        configCwdSource: degradedBoot.cwdSource || "process.cwd",
+        bootstrapAttempted: false
+      };
+    }
     let bootstrapAttempted = false;
     if (!params.inspect && typeof client.ensureReadySafe === "function")
       bootstrapAttempted = await client.ensureReadySafe();

--- a/packages/command-code/package.json
+++ b/packages/command-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/command-code-adapter",
-  "version": "0.7.35",
+  "version": "0.7.36",
   "private": true,
   "type": "module",
   "commandcode": {

--- a/packages/command-code/src/index.ts
+++ b/packages/command-code/src/index.ts
@@ -3,7 +3,7 @@ import { registerParleTools, type DegradedMcpBoot, type ParleMcpClientLike, type
 import { z } from "zod";
 
 const ADAPTER_NAME = "@parlehq/command-code-adapter";
-const ADAPTER_VERSION = "0.7.35";
+const ADAPTER_VERSION = "0.7.36";
 const CUSTOM_MESSAGE_TYPE = "parle/responsive-delivery";
 const STATUS_INTERVAL_MS = 5_000;
 

--- a/packages/command-code/test/index.test.mjs
+++ b/packages/command-code/test/index.test.mjs
@@ -61,7 +61,7 @@ test("root and package manifests expose only the native mod", () => {
   const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
   assert.deepEqual(root.commandcode.mods, ["./packages/command-code/mods/parle.ts"]);
   assert.deepEqual(pkg.commandcode.mods, ["./mods/parle.ts"]);
-  assert.equal(pkg.version, "0.7.35");
+  assert.equal(pkg.version, "0.7.36");
   assert.match(readFileSync(resolve("src/index.ts"), "utf8"), new RegExp(`ADAPTER_VERSION = "${pkg.version}"`));
 
   const artifact = readFileSync(resolve("mods/parle.ts"), "utf8");

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.59 (2026-08-27)
+
+- Resolve configuration from a valid absolute `PWD` launch directory before the process directory and report `configCwd` provenance in status (#169).
+
 ## 0.7.58 (2026-08-31)
 
 - Refresh the shared responsive-delivery controller with fallback deadline and stage evidence (#80).

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.59 (2026-08-27)
 
-- Resolve configuration from a valid absolute `PWD` launch directory before the process directory and report `configCwd` provenance in status (#169).
+- Add opt-in launch-directory configuration: when a host manifest sets `PARLE_CONFIG_CWD_FROM_PWD=1` (the Codex plugin does), resolve configuration from a valid absolute `PWD` before the process directory; report `configCwd` provenance in healthy and degraded status (#169).
 
 ## 0.7.58 (2026-08-31)
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.58",
+  "version": "0.7.59",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { McpServer, type RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { lstatSync, readFileSync, readdirSync } from "node:fs";
+import { lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { connect } from "node:net";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
 import { INBOX_COMPLETENESS_GUIDANCE, INBOX_REPLY_GUIDANCE, SEND_ATTENTION_GUIDANCE, ParleAccountClient, ParleAgentClient, ParleApiError, ProfileConfigError, ProfileNotFoundError, ReadParams, SendParams, SubmitReplyParams, activeRoomSectionFromStatus, assertClientName, assertClientVersion, compactConnectionCardFromSummary, compactStatusCardFromStatus, inspectResponsiveDeliveryPid, processClientInstanceId, readResponsiveDeliverySnapshots, redactString, resolveConfig, resolveResponsiveDelivery, type AcceptRoomInvitationParams, type ActiveRoomInventoryRow, type AddOwnAgentSeatParams, type ClaimPrincipalInviteParams, type ClientOptions, type ConnectOwnAgentParams, type CreateRoomParams, type HardenAccountParams, type LoginParams, type MintPrincipalInviteParams, type OwnedAliasDeliveryParams, type OwnedAliasReleaseParams, type ParleRoomsInventory, type RoomInventorySection, knownAddressContextFor, parseKeyValueFile, resolveProfileCatalogPath } from "@parlehq/agent-client";
@@ -12,7 +12,7 @@ import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, 
 export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.58";
+export const MCP_CLIENT_VERSION = "0.7.59";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {
@@ -23,6 +23,27 @@ export function resolveIntegrationMetadata(env: Record<string, string | undefine
     integrationName: rawName ? assertClientName(rawName) : undefined,
     integrationVersion: rawVersion ? assertClientVersion(rawVersion) : undefined,
   };
+}
+
+export type ConfigCwdSource = "PWD" | "process.cwd";
+export type ConfigCwd = { cwd: string; source: ConfigCwdSource };
+
+// Hosts that spawn the server from an install directory (Codex sets cwd to the
+// plugin cache) still forward PWD, the shell launch directory. Configuration
+// resolution (the project .env, a relative PARLE_PROFILES_PATH) follows PWD
+// only when it is an absolute, existing, realpath-stable directory; anything
+// else falls back to the process directory.
+export function resolveConfigCwd(env: Record<string, string | undefined> = process.env, fallback = process.cwd()): ConfigCwd {
+  const pwd = env.PWD;
+  if (pwd && isAbsolute(pwd)) {
+    try {
+      const resolved = realpathSync(pwd);
+      if (statSync(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
+    } catch {
+      // An unresolvable PWD is not a configuration directory.
+    }
+  }
+  return { cwd: fallback, source: "process.cwd" };
 }
 
 export function createMcpAgentClient(options: ClientOptions = {}): ParleAgentClient {
@@ -65,12 +86,13 @@ export async function runStdio() {
     throw new Error(`Unsupported PARLE_HOOK_BRIDGE_HOST_PROCESS mode: ${hostProcessMode}`);
   }
   const hostParentPid = hostProcessMode === "direct-parent" ? process.ppid : undefined;
+  const configCwd = resolveConfigCwd();
   let stopPreRuntimeParentCheck = hostParentPid === undefined
     ? () => {}
     : scheduleHostParentCheck(hostParentPid, () => process.exit(0));
   const createRuntime = () => {
     const clientEnv = hookBridgeEnabled ? { ...process.env, PARLE_UNREAD_POLL_INTERVAL_SECONDS: "0" } : process.env;
-    const client = createMcpAgentClient({ env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
+    const client = createMcpAgentClient({ cwd: configCwd.cwd, env: clientEnv, publishRuntime: { adapterName: MCP_CLIENT_NAME, adapterVersion: MCP_CLIENT_VERSION } });
     if (hookBridgeEnabled) {
       client.switchProfile = async () => {
         throw new Error("Live Parle profile switching is unavailable while the hook bridge owns responsive delivery. Restart the host with the target PARLE_PROFILE so the MCP session, wake stream, queue, and hook binding change atomically.");
@@ -85,11 +107,14 @@ export async function runStdio() {
         hostParentPid,
       )
       : undefined;
-    if (deliveryBridge) {
-      const baseStatus = client.status.bind(client);
-      client.status = () => ({ ...baseStatus(), responsiveDeliveryBridge: deliveryBridge.status() });
-    }
-    return { client, accountClient: new ParleAccountClient(), deliveryBridge };
+    const baseStatus = client.status.bind(client);
+    client.status = () => ({
+      ...baseStatus(),
+      configCwd: configCwd.cwd,
+      configCwdSource: configCwd.source,
+      ...(deliveryBridge ? { responsiveDeliveryBridge: deliveryBridge.status() } : {}),
+    });
+    return { client, accountClient: new ParleAccountClient({ cwd: configCwd.cwd }), deliveryBridge };
   };
   let activated = false;
   const activateRuntime = (runtime: ReturnType<typeof createRuntime>) => {
@@ -123,7 +148,7 @@ export async function runStdio() {
     ? createParleMcpServer(runtime.client, runtime.accountClient, runtime.deliveryBridge)
     : createParleMcpServer({} as ParleMcpClientLike, new ParleAccountClient(), undefined, {
         error: configError!,
-        cwd: process.cwd(),
+        cwd: configCwd.cwd,
         env: process.env,
         recover: createRuntime,
         onRecovered(recovered) {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -8,8 +8,8 @@ import { pathToFileURL } from "node:url";
 import { z } from "zod";
 import { INBOX_COMPLETENESS_GUIDANCE, INBOX_REPLY_GUIDANCE, SEND_ATTENTION_GUIDANCE, ParleAccountClient, ParleAgentClient, ParleApiError, ProfileConfigError, ProfileNotFoundError, ReadParams, SendParams, SubmitReplyParams, activeRoomSectionFromStatus, assertClientName, assertClientVersion, compactConnectionCardFromSummary, compactStatusCardFromStatus, inspectResponsiveDeliveryPid, processClientInstanceId, readResponsiveDeliverySnapshots, redactString, resolveConfig, resolveResponsiveDelivery, type AcceptRoomInvitationParams, type ActiveRoomInventoryRow, type AddOwnAgentSeatParams, type ClaimPrincipalInviteParams, type ClientOptions, type ConnectOwnAgentParams, type CreateRoomParams, type HardenAccountParams, type LoginParams, type MintPrincipalInviteParams, type OwnedAliasDeliveryParams, type OwnedAliasReleaseParams, type ParleRoomsInventory, type RoomInventorySection, knownAddressContextFor, parseKeyValueFile, resolveProfileCatalogPath } from "@parlehq/agent-client";
 import { HookDeliveryBridge, hookBridgeStateDir, processIsAlive, removeDeadHookBridgeArtifact } from "./hook-delivery-bridge.js";
-import { registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
-export { hostSessionIdFromMeta, registerParleTools, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
+import { registerParleTools, type ConfigCwdSource, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
+export { hostSessionIdFromMeta, registerParleTools, type ConfigCwdSource, type DegradedMcpBoot, type HookDeliveryBridgeLike, type ParleAccountClientLike, type ParleMcpClientLike, type RegisterParleTool } from "./tool-runtime.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
 export const MCP_CLIENT_VERSION = "0.7.59";
@@ -25,17 +25,18 @@ export function resolveIntegrationMetadata(env: Record<string, string | undefine
   };
 }
 
-export type ConfigCwdSource = "PWD" | "process.cwd";
 export type ConfigCwd = { cwd: string; source: ConfigCwdSource };
 
 // Hosts that spawn the server from an install directory (Codex sets cwd to the
-// plugin cache) still forward PWD, the shell launch directory. Configuration
-// resolution (the project .env, a relative PARLE_PROFILES_PATH) follows PWD
-// only when it is an absolute, existing, realpath-stable directory; anything
-// else falls back to the process directory.
+// plugin cache) still forward PWD, the shell launch directory. Only a host
+// manifest that opts in with PARLE_CONFIG_CWD_FROM_PWD=1 lets configuration
+// resolution (the project .env, a relative PARLE_PROFILES_PATH) follow PWD, and
+// then only when it is an absolute, existing, realpath-stable directory. Other
+// hosts (Claude Code runs the server in the project; Claude Desktop is
+// GUI-launched with an unrelated PWD) keep the process directory.
 export function resolveConfigCwd(env: Record<string, string | undefined> = process.env, fallback = process.cwd()): ConfigCwd {
   const pwd = env.PWD;
-  if (pwd && isAbsolute(pwd)) {
+  if (env.PARLE_CONFIG_CWD_FROM_PWD === "1" && pwd && isAbsolute(pwd)) {
     try {
       const resolved = realpathSync(pwd);
       if (statSync(resolved).isDirectory()) return { cwd: resolved, source: "PWD" };
@@ -149,6 +150,7 @@ export async function runStdio() {
     : createParleMcpServer({} as ParleMcpClientLike, new ParleAccountClient(), undefined, {
         error: configError!,
         cwd: configCwd.cwd,
+        cwdSource: configCwd.source,
         env: process.env,
         recover: createRuntime,
         onRecovered(recovered) {

--- a/packages/mcp-server/src/tool-runtime.ts
+++ b/packages/mcp-server/src/tool-runtime.ts
@@ -237,9 +237,12 @@ export function hostSessionIdFromMeta(meta: unknown): string | undefined {
   return undefined;
 }
 
+export type ConfigCwdSource = "PWD" | "process.cwd";
+
 export type DegradedMcpBoot = {
   error: ProfileConfigError;
   cwd?: string;
+  cwdSource?: ConfigCwdSource;
   env?: Record<string, string | undefined>;
   recover: () => {
     client: ParleMcpClientLike;
@@ -292,7 +295,16 @@ export function registerParleTools(
     annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: true },
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    if (degradedBoot) return { ...degradedConfigDiagnostic(degradedBoot.error), bootstrapAttempted: false };
+    // A wrong project .env is a common cause of a degraded boot, so the
+    // directory that was consulted is reported here too.
+    if (degradedBoot) {
+      return {
+        ...degradedConfigDiagnostic(degradedBoot.error),
+        configCwd: degradedBoot.cwd || process.cwd(),
+        configCwdSource: degradedBoot.cwdSource || "process.cwd",
+        bootstrapAttempted: false,
+      };
+    }
     let bootstrapAttempted = false;
     if (!params.inspect && typeof client.ensureReadySafe === "function") bootstrapAttempted = await client.ensureReadySafe();
     if (!params.inspect && deliveryBridge?.start) void deliveryBridge.start().catch(() => undefined);

--- a/packages/mcp-server/src/tool-runtime.ts
+++ b/packages/mcp-server/src/tool-runtime.ts
@@ -3,6 +3,9 @@ import { INBOX_COMPLETENESS_GUIDANCE, INBOX_REPLY_GUIDANCE, SEND_ATTENTION_GUIDA
 import { z } from "zod";
 
 export type ParleMcpClientLike = {
+  // Configuration directory the client resolved (present on ParleAgentClient);
+  // local catalogs beside the profile catalog follow it.
+  cwd?: string;
   status(): unknown;
   setup(): unknown;
   connect(): Promise<unknown>;
@@ -375,7 +378,7 @@ export function registerParleTools(
     annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false },
   }, async (params, extra) => safeTool(async () => {
     observeRequest(extra);
-    const path = resolveSavedStartCatalogPath(process.cwd(), process.env);
+    const path = resolveSavedStartCatalogPath(client.cwd || process.cwd(), process.env);
     if (params.action === "list") {
       return { savedStarts: [...readSavedStarts(path).values()] };
     }

--- a/packages/mcp-server/test/index.test.mjs
+++ b/packages/mcp-server/test/index.test.mjs
@@ -462,6 +462,8 @@ test("MCP degraded boot exposes diagnostics and promotes after profile repair", 
       error: initialError.message,
       selector: "missing",
       availableProfiles: ["other"],
+      configCwd: home,
+      configCwdSource: "process.cwd",
       bootstrapAttempted: false,
     });
 
@@ -1193,7 +1195,7 @@ test("stdio server lists the full tool contract and setup works without secrets"
   }
 });
 
-test("config cwd follows PWD only when it is an absolute existing directory, resolved through realpath", () => {
+test("config cwd follows PWD only when the host opts in and PWD is an absolute existing directory, resolved through realpath", () => {
   const root = mkdtempSync(join(tmpdir(), "parle-mcp-config-cwd-"));
   try {
     const project = join(root, "project");
@@ -1203,24 +1205,30 @@ test("config cwd follows PWD only when it is an absolute existing directory, res
     const file = join(root, "file");
     writeFileSync(file, "");
     const fallback = join(root, "fallback");
-    assert.deepEqual(resolveConfigCwd({ PWD: project }, fallback), { cwd: realpathSync(project), source: "PWD" });
-    assert.deepEqual(resolveConfigCwd({ PWD: link }, fallback), { cwd: realpathSync(project), source: "PWD" });
+    const optIn = { PARLE_CONFIG_CWD_FROM_PWD: "1" };
+    assert.deepEqual(resolveConfigCwd({ ...optIn, PWD: project }, fallback), { cwd: realpathSync(project), source: "PWD" });
+    assert.deepEqual(resolveConfigCwd({ ...optIn, PWD: link }, fallback), { cwd: realpathSync(project), source: "PWD" });
     for (const pwd of [undefined, "", "project", "./project", join(root, "missing"), join(link, "missing"), file]) {
-      assert.deepEqual(resolveConfigCwd({ PWD: pwd }, fallback), { cwd: fallback, source: "process.cwd" }, `PWD=${pwd}`);
+      assert.deepEqual(resolveConfigCwd({ ...optIn, PWD: pwd }, fallback), { cwd: fallback, source: "process.cwd" }, `PWD=${pwd}`);
+    }
+    for (const gate of [undefined, "", "0", "true"]) {
+      assert.deepEqual(resolveConfigCwd({ PARLE_CONFIG_CWD_FROM_PWD: gate, PWD: project }, fallback), { cwd: fallback, source: "process.cwd" }, `gate=${gate}`);
     }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-// Codex spawns plugin MCP servers with env_clear(): only these host defaults
-// plus the names its plugin manifest lists in env_vars reach the child. The
-// fixtures below hand the server exactly that environment; PARLE_* from the
-// test runner's own environment never leaks in.
+// Codex spawns plugin MCP servers with env_clear(): only these host defaults,
+// the names its plugin manifest lists in env_vars, and the manifest's literal
+// env map reach the child. The fixtures below hand the server exactly that
+// environment; PARLE_* from the test runner's own environment never leaks in.
 const CODEX_DEFAULT_ENV_VARS = ["HOME", "PATH", "USER", "TMPDIR", "LANG", "LC_ALL", "TERM", "TZ", "SHELL", "LOGNAME"];
 const CODEX_FORWARDED_ENV_VARS = ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME"];
+// The configuration-relevant subset of the Codex manifest's literal env map.
+const CODEX_MANIFEST_ENV = { PARLE_CONFIG_CWD_FROM_PWD: "1" };
 
-function envClearedSpawnEnv(home, forwarded) {
+function envClearedSpawnEnv(home, forwarded, manifestEnv = CODEX_MANIFEST_ENV) {
   const env = {};
   for (const name of CODEX_DEFAULT_ENV_VARS) if (process.env[name] !== undefined) env[name] = process.env[name];
   env.HOME = home;
@@ -1228,7 +1236,7 @@ function envClearedSpawnEnv(home, forwarded) {
     assert.ok(CODEX_FORWARDED_ENV_VARS.includes(name), `${name} is not forwarded through an env-cleared Codex spawn`);
     if (value !== undefined) env[name] = value;
   }
-  return env;
+  return { ...env, ...manifestEnv };
 }
 
 function writeProfileCatalog(home, sections) {
@@ -1253,12 +1261,12 @@ function envClearedLaunchFixture() {
   return { root, home, install, project, cleanup: () => rmSync(root, { recursive: true, force: true }) };
 }
 
-async function withEnvClearedServer({ home, install, forwarded }, run) {
+async function withEnvClearedServer({ home, install, forwarded, manifestEnv }, run) {
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: [new URL("../dist/parle-mcp.js", import.meta.url).pathname],
     cwd: install,
-    env: envClearedSpawnEnv(home, forwarded),
+    env: envClearedSpawnEnv(home, forwarded, manifestEnv),
     stderr: "pipe",
   });
   const client = new Client({ name: "parle-mcp-env-cleared", version: "0.0.0" }, { capabilities: {} });
@@ -1321,6 +1329,10 @@ test("env-cleared spawn fails closed on a forwarded selector conflict", async ()
       assert.equal(setup.structuredContent.degraded, true);
       assert.equal(setup.structuredContent.code, "profile_config_error");
       assert.match(setup.structuredContent.error, /PARLE_PROFILES from env conflicts with PARLE_PROFILE from env/);
+      const status = await client.callTool({ name: "parle_status", arguments: {} });
+      assert.equal(status.structuredContent.degraded, true);
+      assert.equal(status.structuredContent.configCwd, realpathSync(fixture.project));
+      assert.equal(status.structuredContent.configCwdSource, "PWD");
     });
   } finally {
     fixture.cleanup();
@@ -1338,6 +1350,19 @@ test("env-cleared spawn ignores a relative or missing PWD and falls back to the 
       assert.equal(status.configCwd, realpathSync(fixture.install));
       assert.deepEqual(status.config.profile, { source: "profile_catalog", configured: true, value: "default" });
     }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("env-cleared spawn without the manifest opt-in ignores a valid PWD", async () => {
+  const fixture = envClearedLaunchFixture();
+  try {
+    writeFileSync(join(fixture.project, ".env"), "PARLE_PROFILE=codex\nPARLE_WATCH_ENABLED=0\n");
+    const status = await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project }, manifestEnv: {} }, inspectedStatus);
+    assert.equal(status.configCwdSource, "process.cwd");
+    assert.equal(status.configCwd, realpathSync(fixture.install));
+    assert.deepEqual(status.config.profile, { source: "profile_catalog", configured: true, value: "default" });
   } finally {
     fixture.cleanup();
   }

--- a/packages/mcp-server/test/index.test.mjs
+++ b/packages/mcp-server/test/index.test.mjs
@@ -4,12 +4,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { ParleAgentClient, ParleApiError, ProfileNotFoundError, ResponsiveDeliveryRecorder, processStartedAtIso } from "@parlehq/agent-client";
-import { MCP_CLIENT_INSTANCE_ID, MCP_CLIENT_NAME, MCP_CLIENT_VERSION, WATCHER_USAGE, WatcherUsageError, createMcpAgentClient, createParleMcpServer, hostSessionIdFromMeta, isDirectRun, parseWatcherArgs, runWatcher, scheduleEagerBootstrap, scheduleHostParentCheck } from "../dist/index.js";
+import { MCP_CLIENT_INSTANCE_ID, MCP_CLIENT_NAME, MCP_CLIENT_VERSION, WATCHER_USAGE, WatcherUsageError, createMcpAgentClient, createParleMcpServer, hostSessionIdFromMeta, isDirectRun, parseWatcherArgs, resolveConfigCwd, runWatcher, scheduleEagerBootstrap, scheduleHostParentCheck } from "../dist/index.js";
 
 const expectedTools = [
   "parle_accept_room_invitation",
@@ -1190,6 +1190,156 @@ test("stdio server lists the full tool contract and setup works without secrets"
     assert.equal(send.annotations.openWorldHint, true);
   } finally {
     await client.close();
+  }
+});
+
+test("config cwd follows PWD only when it is an absolute existing directory, resolved through realpath", () => {
+  const root = mkdtempSync(join(tmpdir(), "parle-mcp-config-cwd-"));
+  try {
+    const project = join(root, "project");
+    mkdirSync(project);
+    const link = join(root, "link");
+    symlinkSync(project, link);
+    const file = join(root, "file");
+    writeFileSync(file, "");
+    const fallback = join(root, "fallback");
+    assert.deepEqual(resolveConfigCwd({ PWD: project }, fallback), { cwd: realpathSync(project), source: "PWD" });
+    assert.deepEqual(resolveConfigCwd({ PWD: link }, fallback), { cwd: realpathSync(project), source: "PWD" });
+    for (const pwd of [undefined, "", "project", "./project", join(root, "missing"), join(link, "missing"), file]) {
+      assert.deepEqual(resolveConfigCwd({ PWD: pwd }, fallback), { cwd: fallback, source: "process.cwd" }, `PWD=${pwd}`);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Codex spawns plugin MCP servers with env_clear(): only these host defaults
+// plus the names its plugin manifest lists in env_vars reach the child. The
+// fixtures below hand the server exactly that environment; PARLE_* from the
+// test runner's own environment never leaks in.
+const CODEX_DEFAULT_ENV_VARS = ["HOME", "PATH", "USER", "TMPDIR", "LANG", "LC_ALL", "TERM", "TZ", "SHELL", "LOGNAME"];
+const CODEX_FORWARDED_ENV_VARS = ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME"];
+
+function envClearedSpawnEnv(home, forwarded) {
+  const env = {};
+  for (const name of CODEX_DEFAULT_ENV_VARS) if (process.env[name] !== undefined) env[name] = process.env[name];
+  env.HOME = home;
+  for (const [name, value] of Object.entries(forwarded)) {
+    assert.ok(CODEX_FORWARDED_ENV_VARS.includes(name), `${name} is not forwarded through an env-cleared Codex spawn`);
+    if (value !== undefined) env[name] = value;
+  }
+  return env;
+}
+
+function writeProfileCatalog(home, sections) {
+  mkdirSync(join(home, ".parle"), { mode: 0o700 });
+  const catalog = join(home, ".parle", "profiles");
+  writeFileSync(catalog, sections.map(([name, suffix]) => `[${name}]\nroom_id = 019f2946-aef5-77ad-a41d-747ce0fd6${suffix}\nagent_token = parle_agt_${name}_secret\napi_base = http://127.0.0.1:9\n`).join("\n"), { mode: 0o600 });
+  return catalog;
+}
+
+// The launch fixture mirrors Codex: the process directory is the plugin
+// install, the project is somewhere else, and PWD is the shell launch
+// directory (deliberately not realpath-resolved, tmpdir is a symlink on macOS).
+function envClearedLaunchFixture() {
+  const root = mkdtempSync(join(tmpdir(), "parle-mcp-env-cleared-"));
+  const home = join(root, "home");
+  mkdirSync(home, { mode: 0o700 });
+  const install = join(root, "plugin-cache");
+  mkdirSync(install);
+  const project = join(root, "project");
+  mkdirSync(project);
+  writeProfileCatalog(home, [["default", "a1e"], ["codex", "a1f"], ["other", "a20"]]);
+  return { root, home, install, project, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+async function withEnvClearedServer({ home, install, forwarded }, run) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [new URL("../dist/parle-mcp.js", import.meta.url).pathname],
+    cwd: install,
+    env: envClearedSpawnEnv(home, forwarded),
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "parle-mcp-env-cleared", version: "0.0.0" }, { capabilities: {} });
+  await client.connect(transport);
+  try {
+    return await run(client);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function inspectedStatus(client) {
+  const status = await client.callTool({ name: "parle_status", arguments: { inspect: true } });
+  assert.equal(status.isError, undefined, JSON.stringify(status.structuredContent));
+  return status.structuredContent;
+}
+
+test("env-cleared spawn resolves the project .env from PWD and lets PARLE_PROFILE from env win", async () => {
+  const fixture = envClearedLaunchFixture();
+  try {
+    writeFileSync(join(fixture.project, ".env"), "PARLE_PROFILE=codex\nPARLE_WATCH_ENABLED=0\n");
+    const fromDotEnv = await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project } }, inspectedStatus);
+    assert.equal(fromDotEnv.configCwdSource, "PWD");
+    assert.equal(fromDotEnv.configCwd, realpathSync(fixture.project));
+    assert.deepEqual(fromDotEnv.config.profile, { source: ".env", configured: true, value: "codex" });
+    assert.deepEqual(fromDotEnv.rooms.map((room) => room.profile), ["codex"]);
+
+    const fromEnv = await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project, PARLE_PROFILE: "other" } }, inspectedStatus);
+    assert.deepEqual(fromEnv.config.profile, { source: "env", configured: true, value: "other" });
+    assert.equal(fromEnv.configCwdSource, "PWD");
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("env-cleared spawn forwards PARLE_PROFILES_PATH and multi-room PARLE_PROFILES", async () => {
+  const fixture = envClearedLaunchFixture();
+  try {
+    writeFileSync(join(fixture.project, ".env"), "PARLE_WATCH_ENABLED=0\n");
+    const altHome = join(fixture.root, "alt-home");
+    mkdirSync(altHome, { mode: 0o700 });
+    const altCatalog = writeProfileCatalog(altHome, [["alt", "a21"]]);
+    const relocated = await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project, PARLE_PROFILES_PATH: altCatalog, PARLE_PROFILE: "alt" } }, inspectedStatus);
+    assert.deepEqual(relocated.config.profile, { source: "env", configured: true, value: "alt" });
+
+    const multi = await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project, PARLE_PROFILES: "codex,other" } }, inspectedStatus);
+    assert.deepEqual(multi.rooms.map((room) => room.profile), ["codex", "other"]);
+    assert.equal(multi.configCwdSource, "PWD");
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("env-cleared spawn fails closed on a forwarded selector conflict", async () => {
+  const fixture = envClearedLaunchFixture();
+  try {
+    await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project, PARLE_PROFILES: "codex,other", PARLE_PROFILE: "codex" } }, async (client) => {
+      assert.deepEqual((await client.listTools()).tools.map((tool) => tool.name).sort(), ["parle_delete_profile", "parle_setup", "parle_status"]);
+      const setup = await client.callTool({ name: "parle_setup", arguments: {} });
+      assert.equal(setup.structuredContent.degraded, true);
+      assert.equal(setup.structuredContent.code, "profile_config_error");
+      assert.match(setup.structuredContent.error, /PARLE_PROFILES from env conflicts with PARLE_PROFILE from env/);
+    });
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("env-cleared spawn ignores a relative or missing PWD and falls back to the process directory", async () => {
+  const fixture = envClearedLaunchFixture();
+  try {
+    // The project .env names [codex]; a fallback to the plugin cache must not see it.
+    writeFileSync(join(fixture.project, ".env"), "PARLE_PROFILE=codex\nPARLE_WATCH_ENABLED=0\n");
+    for (const pwd of ["project", join(fixture.root, "missing")]) {
+      const status = await withEnvClearedServer({ ...fixture, forwarded: { PWD: pwd } }, inspectedStatus);
+      assert.equal(status.configCwdSource, "process.cwd", `PWD=${pwd}`);
+      assert.equal(status.configCwd, realpathSync(fixture.install));
+      assert.deepEqual(status.config.profile, { source: "profile_catalog", configured: true, value: "default" });
+    }
+  } finally {
+    fixture.cleanup();
   }
 });
 


### PR DESCRIPTION
Closes #169. Stack 1/7 (base: main).

Codex spawns plugin MCP servers env-cleared, so `PARLE_PROFILE`/`PARLE_PROFILES`/`PARLE_PROFILES_PATH` never reached the server and `cwd: "."` kept the project `.env` unread. Adds the `env_vars` whitelist (+ `PWD`, `CODEX_HOME`), resolves the project `.env` from `PWD` only when the manifest opts in (`PARLE_CONFIG_CWD_FROM_PWD=1`, set by the Codex plugin only), reports `configCwd`/`configCwdSource` in healthy and degraded status, README per-project recipe (mise/direnv). Other hosts unchanged.

Reviewed by Codex (gpt-5.6-sol) to APPROVE; CI sequence (check:manifests, build, typecheck, test, check:mcp-artifacts, check:release-claims) green locally. Env-cleared spawn tests cover propagation, selector conflicts, multi-room, PWD fallback and the gate.

https://claude.ai/code/session_01NqUKRXvGPPpPfGR96RufBQ
