### PR TITLE
codex-plugin: forward PARLE_ALLOW_INSECURE_LOCAL for local rigs (#175)

### DIFF
--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.64",
+  "version": "0.6.65",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -11,7 +11,8 @@
         "PARLE_PROFILES",
         "PARLE_PROFILES_PATH",
         "PWD",
-        "CODEX_HOME"
+        "CODEX_HOME",
+        "PARLE_ALLOW_INSECURE_LOCAL"
       ],
       "env": {
         "PARLE_CONFIG_CWD_FROM_PWD": "1",
@@ -19,7 +20,7 @@
         "PARLE_HOOK_BRIDGE_SCOPE": "codex-plugin",
         "PARLE_HOST_IDLE_WAKE": "none",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.64"
+        "PARLE_INTEGRATION_VERSION": "0.6.65"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.65 (2026-08-27)
+
+- Forward `PARLE_ALLOW_INSECURE_LOCAL` through Codex's cleared MCP environment so a project can reach a local Parle rig (`http://127.0.0.1:<port>`) under Codex. The flag is a non-secret opt-in read from the launching shell's process environment; the shared client's loopback-only rule is unchanged, so it never admits a non-local host (#175).
+
 ## 0.6.64 (2026-08-27)
 
 - Add an identity checkpoint to the skill's safety floor, covering every send path including status-first auto-connect: before this session's first `parle_send` or `parle_reply`, compare the connect or connected-status result's `identity` with any profile, agent, or room the operator stated; on a mismatch or unconfirmable expectation, do not send and report `identity mismatch` with the expected and actual values. When the requested `PARLE_PROFILE` is not in the catalog, or the plugin booted without usable configuration, report it as an identity/configuration problem and never fall back to another profile or the default identity. Carries MCP server 0.7.62 (#172).

--- a/packages/codex-plugin/README.md
+++ b/packages/codex-plugin/README.md
@@ -34,7 +34,7 @@ Codex should discover the Parle skill and MCP tools, call `parle_connect`, then 
 
 ## Profile selection per project
 
-Codex starts plugin MCP servers with a cleared environment and the plugin cache directory as the working directory. The child receives Codex's default variables (`HOME`, `PATH`, `USER`, `TMPDIR`, `LANG`, `LC_ALL`, `TERM`, `TZ`, `SHELL`, `LOGNAME`), the plugin manifest's literal values, and, forwarded from the launching shell, `PARLE_PROFILE`, `PARLE_PROFILES`, `PARLE_PROFILES_PATH`, `PWD`, and `CODEX_HOME`. Nothing else from the shell reaches the server. The manifest's literal `PARLE_CONFIG_CWD_FROM_PWD=1` opts this host into resolving project configuration, including a project `.env`, from `PWD`, the directory the shell was in when `codex` started. This recipe forwards no Parle credential variables; keep credentials in `~/.parle/profiles` and select them by name. The resolver can also read direct credentials from a project `.env`, but the recipe below does not rely on that.
+Codex starts plugin MCP servers with a cleared environment and the plugin cache directory as the working directory. The child receives Codex's default variables (`HOME`, `PATH`, `USER`, `TMPDIR`, `LANG`, `LC_ALL`, `TERM`, `TZ`, `SHELL`, `LOGNAME`), the plugin manifest's literal values, and, forwarded from the launching shell, `PARLE_PROFILE`, `PARLE_PROFILES`, `PARLE_PROFILES_PATH`, `PWD`, `CODEX_HOME`, and `PARLE_ALLOW_INSECURE_LOCAL`. Nothing else from the shell reaches the server. The manifest's literal `PARLE_CONFIG_CWD_FROM_PWD=1` opts this host into resolving project configuration, including a project `.env`, from `PWD`, the directory the shell was in when `codex` started. This recipe forwards no Parle credential variables; keep credentials in `~/.parle/profiles` and select them by name. The resolver can also read direct credentials from a project `.env`, but the recipe below does not rely on that.
 
 Pin a profile to a project with a directory-scoped environment. In `.mise.toml`:
 
@@ -52,6 +52,8 @@ export PARLE_PROFILE=codex
 Run `mise trust` or `direnv allow` once, then launch `codex` from the project directory. A project `.env` containing `PARLE_PROFILE=codex` also works because the server reads it from the launch directory; a value in the process environment wins over `.env`. `parle_status` reports `configCwd` and `configCwdSource` (`PWD` or `process.cwd`) so the directory that was used is visible.
 
 `PWD` means the shell launch directory. `codex -C elsewhere` changes the session working directory without changing `PWD`, so it does not select that directory's Parle configuration.
+
+To use a local Parle rig, export `PARLE_ALLOW_INSECURE_LOCAL=1` in the same directory-scoped environment (mise or direnv); it only permits loopback hosts, and the server reads it from the process environment, not from the project `.env`.
 
 Because the server now treats the launch directory as its configuration directory, credential-free runtime snapshots appear under `<project>/.parle/runtime/` (see [`docs/design/storage-layout.md`](../../docs/design/storage-layout.md)), as they already do for other hosts. Add `.parle/runtime/` to the project `.gitignore`.
 

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.64",
+  "version": "0.6.65",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/codex-plugin/test/index.test.mjs
+++ b/packages/codex-plugin/test/index.test.mjs
@@ -21,7 +21,7 @@ test("Codex plugin metadata and MCP config point at the bundled server", () => {
   assert.equal(mcp.mcpServers.parle.command, "node");
   assert.deepEqual(mcp.mcpServers.parle.args, ["./dist/parle-mcp.js"]);
   assert.equal(mcp.mcpServers.parle.cwd, ".");
-  assert.deepEqual(mcp.mcpServers.parle.env_vars, ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME"]);
+  assert.deepEqual(mcp.mcpServers.parle.env_vars, ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME", "PARLE_ALLOW_INSECURE_LOCAL"]);
   assert.deepEqual(mcp.mcpServers.parle.env, {
     PARLE_CONFIG_CWD_FROM_PWD: "1",
     PARLE_RESPONSIVE_DELIVERY: "hook-bridge",
@@ -63,6 +63,11 @@ test("Codex MCP config forwards only non-credential selectors from the launching
   assert.equal(server.env_vars.includes("PARLE_CONFIG_CWD_FROM_PWD"), false, "the opt-in is a literal value, never forwarded from the shell");
   assert.equal(server.env_vars.includes("CODEX_HOME"), true, "a later codex subprocess must target the parent's state store");
   assert.equal(server.env_vars.includes("PARLE_ROOM_AGENT_TOKEN"), false);
+  // A local Parle rig is reachable only when the shell opts in; the value is a
+  // non-secret flag and the shared client still admits loopback hosts only (#175).
+  assert.equal(server.env_vars.includes("PARLE_ALLOW_INSECURE_LOCAL"), true, "the loopback opt-in must reach the env-cleared child");
+  assert.doesNotMatch("PARLE_ALLOW_INSECURE_LOCAL", credentialShape);
+  assert.equal(Object.hasOwn(server.env, "PARLE_ALLOW_INSECURE_LOCAL"), false, "the opt-in is forwarded from the shell, never a manifest literal");
 });
 
 test("Codex MCP config declares that the host has no idle-wake arm action", () => {

--- a/packages/mcp-server/test/index.test.mjs
+++ b/packages/mcp-server/test/index.test.mjs
@@ -1473,7 +1473,7 @@ test("config cwd follows PWD only when the host opts in and PWD is an absolute e
 // env map reach the child. The fixtures below hand the server exactly that
 // environment; PARLE_* from the test runner's own environment never leaks in.
 const CODEX_DEFAULT_ENV_VARS = ["HOME", "PATH", "USER", "TMPDIR", "LANG", "LC_ALL", "TERM", "TZ", "SHELL", "LOGNAME"];
-const CODEX_FORWARDED_ENV_VARS = ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME"];
+const CODEX_FORWARDED_ENV_VARS = ["PARLE_PROFILE", "PARLE_PROFILES", "PARLE_PROFILES_PATH", "PWD", "CODEX_HOME", "PARLE_ALLOW_INSECURE_LOCAL"];
 // The configuration-relevant subset of the Codex manifest's literal env map.
 const CODEX_MANIFEST_ENV = { PARLE_CONFIG_CWD_FROM_PWD: "1" };
 
@@ -1820,5 +1820,53 @@ test("a degraded boot with a missing profile says the profile is not in the cata
     await client.close();
     await server.close();
     rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("env-cleared spawn accepts a loopback api_base only when PARLE_ALLOW_INSECURE_LOCAL is forwarded (#175)", async () => {
+  const fixture = envClearedLaunchFixture();
+  const api = createServer((request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    const reply = (body, status = 200) => {
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify(body));
+    };
+    if (url.pathname === "/v/agent/sessions") return reply({ agent_session_id: "as-local", session_credential: "parle_ses_local_secret", session_handle: "local", address: "@p.a.local", expires_at: new Date(Date.now() + 3_600_000).toISOString() }, 201);
+    if (url.pathname.endsWith("/participants")) return reply({ participant_id: "part-1", room_handle: "rig" }, 201);
+    if (url.pathname.endsWith("/projection")) return reply({ watermark: 0, messages: [] });
+    if (url.pathname.endsWith("/responsive-delivery")) return reply({ messages: [] });
+    return reply({});
+  });
+  await new Promise((resolveListen) => api.listen(0, "127.0.0.1", resolveListen));
+  const apiBase = `http://127.0.0.1:${api.address().port}`;
+  try {
+    writeFileSync(join(fixture.project, ".env"), "PARLE_WATCH_ENABLED=0\n");
+    writeFileSync(join(fixture.home, ".parle", "profiles"), `[local]\nroom_id = 019f2946-aef5-77ad-a41d-747ce0fd6a1e\nagent_token = parle_agt_local_secret\napi_base = ${apiBase}\n`, { mode: 0o600 });
+
+    // Without the opt-in the shared client's allowlist refuses the loopback base.
+    const refused = await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project, PARLE_PROFILE: "local" } }, async (client) => {
+      assert.equal((await client.listTools()).tools.some((tool) => tool.name === "parle_connect"), true, "a loopback base is a configuration, not a degraded boot");
+      return client.callTool({ name: "parle_connect", arguments: {} });
+    });
+    assert.equal(refused.isError, true);
+    assert.match(refused.structuredContent.error, /Parle API base must use https/);
+
+    const accepted = await withEnvClearedServer({ ...fixture, forwarded: { PWD: fixture.project, PARLE_PROFILE: "local", PARLE_ALLOW_INSECURE_LOCAL: "1" } }, async (client) => {
+      const connect = await client.callTool({ name: "parle_connect", arguments: {} });
+      assert.equal(connect.isError, undefined, JSON.stringify(connect.structuredContent));
+      assert.equal(connect.structuredContent.connected, true);
+      assert.equal(connect.structuredContent.identity.sessionAddress, "@p.a.local");
+      assert.equal(connect.structuredContent.identity.roomHandle, "rig");
+      const status = await inspectedStatus(client);
+      assert.equal(status.configCwdSource, "PWD");
+      assert.equal(status.config.apiBase.value, apiBase);
+      assert.equal(status.runtime.bootstrapState, "ready");
+      assert.equal(status.runtime.lastBootstrapError, undefined);
+      return { connect, status };
+    });
+    for (const sensitive of ["parle_agt_local_secret", "parle_ses_local_secret"]) assert.equal(JSON.stringify(accepted).includes(sensitive), false);
+  } finally {
+    fixture.cleanup();
+    await new Promise((resolveClose) => api.close(resolveClose));
   }
 });


### PR DESCRIPTION
Closes #175. Stack 6/7 (base: feat/172).

Forwards `PARLE_ALLOW_INSECURE_LOCAL` through `env_vars` so the plugin can reach a loopback Parle rig under Codex's env-cleared MCP spawn (loopback-only rule unchanged; a test asserts it is never a manifest literal).

Reviewed by Codex (gpt-5.6-sol) to APPROVE; CI sequence (check:manifests, build, typecheck, test, check:mcp-artifacts, check:release-claims) green locally.

https://claude.ai/code/session_01NqUKRXvGPPpPfGR96RufBQ
