### PR TITLE
Fix Codex idle wake under macOS Agent Safehouse

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.71 (2026-09-06)
+
+- Refresh the bundled MCP server to 0.7.71. Claude Desktop behavior is unchanged.
+
 ## 0.8.70 (2026-09-06)
 
 - Carry server 0.7.70 so the room tool descriptions enforce details-first owner checks and privacy-safe live-session output.

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.70",
+  "version": "0.8.71",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.70"
+        "PARLE_INTEGRATION_VERSION": "0.8.71"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.70",
+  "version": "0.8.71",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -42880,17 +42880,33 @@ async function readParentProcess(pid, platform, deps) {
   const env = hostSubprocessEnv(deps.env);
   const probe = async (args2) => {
     const outcome = await execFile("/bin/ps", ["-o", ...args2, "-p", String(pid)], { timeout: PROBE_TIMEOUT_MS, env });
+    if (outcome.spawnError) throw new Error(outcome.spawnError);
     if (outcome.code !== 0) throw new Error(`/bin/ps exited ${outcome.code ?? outcome.signal}`);
     return outcome.stdout.trim();
   };
-  let path = await probe(["comm="]);
-  if (!isAbsolute3(path)) {
+  const lsofExecutable = async () => {
     const outcome = await execFile("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { timeout: PROBE_TIMEOUT_MS, env });
     const executable = outcome.stdout.split("\n").find((line2) => line2.startsWith("n/"));
-    if (outcome.code !== 0 || !executable) throw new Error("parent executable path is not absolute");
-    path = executable.slice(1);
+    if (outcome.spawnError || outcome.code !== 0 || !executable) throw new Error(outcome.spawnError ?? "parent executable path is not absolute");
+    return executable.slice(1);
+  };
+  let path;
+  try {
+    path = await probe(["comm="]);
+  } catch (error51) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage2(error51))) throw error51;
+    path = await lsofExecutable();
+    return { path, args: [] };
   }
-  const args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  if (!isAbsolute3(path)) {
+    path = await lsofExecutable();
+  }
+  let args = [];
+  try {
+    args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  } catch (error51) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage2(error51))) throw error51;
+  }
   return { path, args };
 }
 async function resolveCodexHostExecutable(hostParentPid, deps = {}) {
@@ -44608,7 +44624,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.70";
+var MCP_CLIENT_VERSION = "0.7.71";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.75",
+  "version": "0.9.76",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_HOST_IDLE_WAKE": "claude-monitor",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.75"
+        "PARLE_INTEGRATION_VERSION": "0.9.76"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.76 (2026-09-06)
+
+- Refresh the bundled MCP server to 0.7.71. Claude Monitor behavior is unchanged.
+
 ## 0.9.75 (2026-09-06)
 
 - Carry server 0.7.70 so the room tool descriptions enforce details-first owner checks and privacy-safe live-session output.

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -42880,17 +42880,33 @@ async function readParentProcess(pid, platform, deps) {
   const env = hostSubprocessEnv(deps.env);
   const probe = async (args2) => {
     const outcome = await execFile("/bin/ps", ["-o", ...args2, "-p", String(pid)], { timeout: PROBE_TIMEOUT_MS, env });
+    if (outcome.spawnError) throw new Error(outcome.spawnError);
     if (outcome.code !== 0) throw new Error(`/bin/ps exited ${outcome.code ?? outcome.signal}`);
     return outcome.stdout.trim();
   };
-  let path = await probe(["comm="]);
-  if (!isAbsolute3(path)) {
+  const lsofExecutable = async () => {
     const outcome = await execFile("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { timeout: PROBE_TIMEOUT_MS, env });
     const executable = outcome.stdout.split("\n").find((line2) => line2.startsWith("n/"));
-    if (outcome.code !== 0 || !executable) throw new Error("parent executable path is not absolute");
-    path = executable.slice(1);
+    if (outcome.spawnError || outcome.code !== 0 || !executable) throw new Error(outcome.spawnError ?? "parent executable path is not absolute");
+    return executable.slice(1);
+  };
+  let path;
+  try {
+    path = await probe(["comm="]);
+  } catch (error51) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage2(error51))) throw error51;
+    path = await lsofExecutable();
+    return { path, args: [] };
   }
-  const args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  if (!isAbsolute3(path)) {
+    path = await lsofExecutable();
+  }
+  let args = [];
+  try {
+    args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  } catch (error51) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage2(error51))) throw error51;
+  }
   return { path, args };
 }
 async function resolveCodexHostExecutable(hostParentPid, deps = {}) {
@@ -44608,7 +44624,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.70";
+var MCP_CLIENT_VERSION = "0.7.71";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.75",
+  "version": "0.9.76",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.73",
+  "version": "0.6.74",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -21,7 +21,7 @@
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_HOST_IDLE_WAKE": "codex-queue",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.73"
+        "PARLE_INTEGRATION_VERSION": "0.6.74"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.74 (2026-09-06)
+
+- Carry server 0.7.71 so Safehouse-backed Codex sessions can verify the host through `lsof` when macOS refuses to spawn `ps`.
+
 ## 0.6.73 (2026-09-06)
 
 - Load the Parle skill for bare room-membership and presence prompts, and carry server 0.7.70 so the always-visible room tool descriptions enforce owner-gated, privacy-safe live-session reporting.

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -42880,17 +42880,33 @@ async function readParentProcess(pid, platform, deps) {
   const env = hostSubprocessEnv(deps.env);
   const probe = async (args2) => {
     const outcome = await execFile("/bin/ps", ["-o", ...args2, "-p", String(pid)], { timeout: PROBE_TIMEOUT_MS, env });
+    if (outcome.spawnError) throw new Error(outcome.spawnError);
     if (outcome.code !== 0) throw new Error(`/bin/ps exited ${outcome.code ?? outcome.signal}`);
     return outcome.stdout.trim();
   };
-  let path = await probe(["comm="]);
-  if (!isAbsolute3(path)) {
+  const lsofExecutable = async () => {
     const outcome = await execFile("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { timeout: PROBE_TIMEOUT_MS, env });
     const executable = outcome.stdout.split("\n").find((line2) => line2.startsWith("n/"));
-    if (outcome.code !== 0 || !executable) throw new Error("parent executable path is not absolute");
-    path = executable.slice(1);
+    if (outcome.spawnError || outcome.code !== 0 || !executable) throw new Error(outcome.spawnError ?? "parent executable path is not absolute");
+    return executable.slice(1);
+  };
+  let path;
+  try {
+    path = await probe(["comm="]);
+  } catch (error51) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage2(error51))) throw error51;
+    path = await lsofExecutable();
+    return { path, args: [] };
   }
-  const args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  if (!isAbsolute3(path)) {
+    path = await lsofExecutable();
+  }
+  let args = [];
+  try {
+    args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  } catch (error51) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage2(error51))) throw error51;
+  }
   return { path, args };
 }
 async function resolveCodexHostExecutable(hostParentPid, deps = {}) {
@@ -44608,7 +44624,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.70";
+var MCP_CLIENT_VERSION = "0.7.71";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.73",
+  "version": "0.6.74",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.71 (2026-09-06)
+
+- On macOS, fall back to `lsof` only when sandbox policy denies `ps`, then retain canonical-path, ownership, mode, inode, version, parent-stability, and pre-exec drift checks before invoking `codex queue`.
+
 ## 0.7.70 (2026-09-06)
 
 - Make live-presence routing self-contained in the room tool descriptions: read room details first, enforce the owner gate, render the exact privacy-safe fallback, aggregate by agent, and omit session identifiers and timestamps by default.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.70",
+  "version": "0.7.71",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/codex-host.ts
+++ b/packages/mcp-server/src/codex-host.ts
@@ -153,19 +153,39 @@ async function readParentProcess(pid: number, platform: NodeJS.Platform, deps: C
   const env = hostSubprocessEnv(deps.env);
   const probe = async (args: string[]) => {
     const outcome = await execFile("/bin/ps", ["-o", ...args, "-p", String(pid)], { timeout: PROBE_TIMEOUT_MS, env });
+    if (outcome.spawnError) throw new Error(outcome.spawnError);
     if (outcome.code !== 0) throw new Error(`/bin/ps exited ${outcome.code ?? outcome.signal}`);
     return outcome.stdout.trim();
   };
-  let path = await probe(["comm="]);
+  const lsofExecutable = async () => {
+    const outcome = await execFile("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { timeout: PROBE_TIMEOUT_MS, env });
+    const executable = outcome.stdout.split("\n").find((line) => line.startsWith("n/"));
+    if (outcome.spawnError || outcome.code !== 0 || !executable) throw new Error(outcome.spawnError ?? "parent executable path is not absolute");
+    return executable.slice(1);
+  };
+  let path: string;
+  try {
+    path = await probe(["comm="]);
+  } catch (error) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage(error))) throw error;
+    // Agent Safehouse permits lsof with process inspection enabled but macOS
+    // still refuses to spawn ps. The executable remains independently pinned below.
+    path = await lsofExecutable();
+    return { path, args: [] };
+  }
   if (!isAbsolute(path)) {
     // macOS ps reports argv[0] as typed; a PATH-launched host shows a bare
     // name. lsof lists the executable's text mapping by absolute path.
-    const outcome = await execFile("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { timeout: PROBE_TIMEOUT_MS, env });
-    const executable = outcome.stdout.split("\n").find((line) => line.startsWith("n/"));
-    if (outcome.code !== 0 || !executable) throw new Error("parent executable path is not absolute");
-    path = executable.slice(1);
+    path = await lsofExecutable();
   }
-  const args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  let args: string[] = [];
+  try {
+    args = (await probe(["args="])).split(/\s+/).filter(Boolean);
+  } catch (error) {
+    if (!/\b(?:EACCES|EPERM)\b/.test(errorMessage(error))) throw error;
+    // As on Linux when cmdline is unavailable, retain executable verification
+    // and omit only the remote-topology check.
+  }
   return { path, args };
 }
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -15,7 +15,7 @@ export { CODEX_QUEUE_WAKE_TRIGGER, CodexQueueWake, MIN_CODEX_QUEUE_VERSION, reso
 export { CLAUDE_MONITOR_WAKE_FRAME, ClaudeMonitorWake } from "./claude-monitor-wake.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.70";
+export const MCP_CLIENT_VERSION = "0.7.71";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {

--- a/packages/mcp-server/test/codex-host.test.mjs
+++ b/packages/mcp-server/test/codex-host.test.mjs
@@ -77,6 +77,7 @@ function linuxDeps(overrides = {}) {
 
 const psComm = (value) => [(file, args) => file === "/bin/ps" && args[1] === "comm=", ok(`${value}\n`)];
 const psArgs = (value) => [(file, args) => file === "/bin/ps" && args[1] === "args=", ok(`${value}\n`)];
+const psSpawnDenied = (code = "EPERM", field) => [(file, args) => file === "/bin/ps" && (!field || args[1] === field), () => { throw Object.assign(new Error(`spawn ${code}`), { code }); }];
 const lsofText = (path) => [(file) => file === "/usr/sbin/lsof", ok(`p${PARENT}\nftxt\nn${path}\nftxt\nn/usr/lib/dyld\n`)];
 
 function darwinDeps(handlers, overrides = {}) {
@@ -154,6 +155,26 @@ test("codex host discovery on macOS accepts an absolute ps comm and falls back t
   const noText = await resolveCodexHostExecutable(PARENT, darwinDeps([psComm("codex"), [(file) => file === "/usr/sbin/lsof", ok(`p${PARENT}\n`)], psArgs("codex")]));
   assert.equal(noText.ok, false);
   assert.equal(noText.reason, "parent-not-codex");
+});
+
+test("codex host discovery on macOS falls back to lsof only when ps execution is denied", async () => {
+  const calls = [];
+  const safehouse = await resolveCodexHostExecutable(PARENT, darwinDeps([], {
+    execFile: fakeExec([psSpawnDenied("EPERM", "comm="), lsofText(CODEX), versionBanner("0.150.1")], calls),
+  }));
+  assert.equal(safehouse.ok, true, JSON.stringify(safehouse));
+  assert.deepEqual(calls.map((call) => call.file), ["/bin/ps", "/usr/sbin/lsof", CODEX]);
+
+  const argsDenied = await resolveCodexHostExecutable(PARENT, darwinDeps([
+    psComm(CODEX),
+    psSpawnDenied("EACCES", "args="),
+  ]));
+  assert.equal(argsDenied.ok, true, JSON.stringify(argsDenied));
+
+  const otherFailure = await resolveCodexHostExecutable(PARENT, darwinDeps([
+    [(file, args) => file === "/bin/ps" && args[1] === "comm=", failed(1, "no such process")],
+  ]));
+  assert.deepEqual(otherFailure, { ok: false, reason: "parent-not-codex", detail: "/bin/ps exited 1" });
 });
 
 test("codex host discovery refuses a relative path, remote topology, wrong uid, non-executable, and a changed parent", async () => {


### PR DESCRIPTION
## Why

Agent Safehouse on macOS refuses to spawn `/bin/ps` even with its full `process-control` feature. That prevents the Codex MCP bridge from verifying its parent, so idle wake remains unavailable.

Live capability evidence from the same sandboxed Codex session:

- `ps`: `EPERM`
- `lsof`: succeeds
- `pgrep`: succeeds
- verified Codex executable with `--version`: succeeds

## Change

- Fall back to `/usr/sbin/lsof` only for explicit `EPERM` or `EACCES` from `ps`.
- Preserve the existing canonical-path, ownership, mode, inode, version, parent-stability, and pre-exec drift checks.
- Treat unavailable macOS argv like unreadable Linux cmdline, losing only the remote-topology check.
- Keep all other `ps` failures fail-closed.
- Refresh and version the MCP artifact wrappers.

Closes #204.

## Validation

- `pnpm typecheck`
- `pnpm check:manifests`
- `pnpm check:mcp-artifacts`
- `pnpm check:release-claims`
- `pnpm --filter @parlehq/mcp-server build && node --test packages/mcp-server/test/codex-host.test.mjs`
- Independent security review: approved with no blockers

The full local suite's Unix-socket tests cannot bind temporary sockets from the current Agent Safehouse session. CI remains the clean-environment validation gate.
