### PR TITLE
fix(codex): bind Safehouse hooks without ps

### DIFF
--- a/packages/claude-desktop-extension/CHANGELOG.md
+++ b/packages/claude-desktop-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.72 (2026-09-06)
+
+- Refresh the bundled MCP server to 0.7.72. Claude Desktop behavior is unchanged.
+
 ## 0.8.71 (2026-09-06)
 
 - Refresh the bundled MCP server to 0.7.71. Claude Desktop behavior is unchanged.

--- a/packages/claude-desktop-extension/manifest.json
+++ b/packages/claude-desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "parle-claude-desktop-extension",
   "display_name": "Parle",
-  "version": "0.8.71",
+  "version": "0.8.72",
   "description": "Claude Desktop extension for Parle room tools through a bundled local MCP server",
   "author": {
     "name": "Parle"
@@ -30,7 +30,7 @@
         "PARLE_ROOM_ID": "${user_config.parle_room_id}",
         "PARLE_ROOM_AGENT_TOKEN": "${user_config.parle_agent_token}",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-desktop-extension",
-        "PARLE_INTEGRATION_VERSION": "0.8.71"
+        "PARLE_INTEGRATION_VERSION": "0.8.72"
       }
     }
   },

--- a/packages/claude-desktop-extension/package.json
+++ b/packages/claude-desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-desktop-extension",
-  "version": "0.8.71",
+  "version": "0.8.72",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/claude-desktop-extension/server/parle-mcp.js
+++ b/packages/claude-desktop-extension/server/parle-mcp.js
@@ -44624,7 +44624,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.71";
+var MCP_CLIENT_VERSION = "0.7.72";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-claude-plugin",
-  "version": "0.9.76",
+  "version": "0.9.77",
   "description": "Claude Code plugin for Parle room tools through the bundled MCP server",
   "author": {
     "name": "Parle"

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -10,7 +10,7 @@
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_HOST_IDLE_WAKE": "claude-monitor",
         "PARLE_INTEGRATION_NAME": "@parlehq/claude-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.9.76"
+        "PARLE_INTEGRATION_VERSION": "0.9.77"
       },
       "alwaysLoad": true
     }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.77 (2026-09-06)
+
+- Refresh the bundled MCP server and shared hook to 0.7.72. Claude Monitor behavior is unchanged.
+
 ## 0.9.76 (2026-09-06)
 
 - Refresh the bundled MCP server to 0.7.71. Claude Monitor behavior is unchanged.

--- a/packages/claude-plugin/dist/parle-mcp.js
+++ b/packages/claude-plugin/dist/parle-mcp.js
@@ -44624,7 +44624,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.71";
+var MCP_CLIENT_VERSION = "0.7.72";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/claude-plugin/hooks/parle-hook.mjs
+++ b/packages/claude-plugin/hooks/parle-hook.mjs
@@ -121,9 +121,25 @@ function isNonResponding(error) {
 const MAX_HOST_ANCESTRY = 8;
 const CODEX_EXECUTABLE_NAME = /^codex(?:[-.][\w.-]*)?$/i;
 
+function processInfoFromLsof(pid, exec = execFileSync) {
+  try {
+    const listing = exec("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-FpRn"], { encoding: "utf8", timeout: 3000, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] });
+    const lines = listing.split("\n");
+    const parentPid = Number(lines.find((entry) => entry.startsWith("R"))?.slice(1));
+    const path = lines.find((entry) => entry.startsWith("n/"))?.slice(1);
+    return { parentPid: Number.isSafeInteger(parentPid) ? parentPid : undefined, path };
+  } catch {
+    return {};
+  }
+}
+
+function psAccessDenied(error) {
+  return ["EACCES", "EPERM"].includes(error?.code) || /\b(?:EACCES|EPERM)\b/.test(error instanceof Error ? error.message : String(error));
+}
+
 // Parent of a live process: /proc where it exists, otherwise the fixed ps
-// binary. Undefined ends the walk.
-function parentPidOf(pid) {
+// binary. Agent Safehouse may deny ps while permitting read-only lsof.
+export function parentPidOf(pid, { exec = execFileSync, platform = process.platform } = {}) {
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
     const parent = Number(stat.slice(stat.lastIndexOf(")") + 2).split(" ")[1]);
@@ -131,40 +147,34 @@ function parentPidOf(pid) {
   } catch {
     // Not Linux, or the process is gone.
   }
-  if (process.platform === "win32") return undefined;
+  if (platform === "win32") return undefined;
   try {
-    const parent = Number(execFileSync("/bin/ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim());
+    const parent = Number(exec("/bin/ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim());
     return Number.isSafeInteger(parent) ? parent : undefined;
-  } catch {
-    return undefined;
+  } catch (error) {
+    return platform === "darwin" && psAccessDenied(error) ? processInfoFromLsof(pid, exec).parentPid : undefined;
   }
 }
 
 // Executable path of a live process without a PATH lookup: /proc where it
-// exists; otherwise ps, which on macOS reports argv[0] as typed, and the lsof
-// text mapping for the absolute path only when that bare name could be Codex.
-function executablePathOf(pid) {
+// exists; otherwise ps, which on macOS reports argv[0] as typed, and lsof for
+// a PATH-launched host or when Agent Safehouse denies ps.
+export function executablePathOf(pid, { exec = execFileSync, platform = process.platform } = {}) {
   try {
     return readlinkSync(`/proc/${pid}/exe`);
   } catch {
     // Not Linux, not our process, or gone.
   }
-  if (process.platform !== "darwin") return undefined;
+  if (platform !== "darwin") return undefined;
   let comm;
   try {
-    comm = execFileSync("/bin/ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim();
-  } catch {
-    return undefined;
+    comm = exec("/bin/ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim();
+  } catch (error) {
+    return psAccessDenied(error) ? processInfoFromLsof(pid, exec).path : undefined;
   }
   if (isAbsolute(comm)) return comm;
   if (!CODEX_EXECUTABLE_NAME.test(basename(comm.replace(/^-/, "")))) return undefined;
-  try {
-    const listing = execFileSync("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { encoding: "utf8", timeout: 3000, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] });
-    const line = listing.split("\n").find((entry) => entry.startsWith("n/"));
-    return line ? line.slice(1) : undefined;
-  } catch {
-    return undefined;
-  }
+  return processInfoFromLsof(pid, exec).path;
 }
 
 // The executable rule the bridge applies to its own parent: owned by this

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/claude-plugin",
-  "version": "0.9.76",
+  "version": "0.9.77",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "parle-codex-plugin",
-  "version": "0.6.74",
+  "version": "0.6.75",
   "description": "Parle room tools for Codex through the bundled Parle MCP server",
   "author": {
     "name": "Parle"

--- a/packages/codex-plugin/.mcp.json
+++ b/packages/codex-plugin/.mcp.json
@@ -21,7 +21,7 @@
         "PARLE_HOOK_BRIDGE_HOST_PROCESS": "direct-parent",
         "PARLE_HOST_IDLE_WAKE": "codex-queue",
         "PARLE_INTEGRATION_NAME": "@parlehq/codex-plugin",
-        "PARLE_INTEGRATION_VERSION": "0.6.74"
+        "PARLE_INTEGRATION_VERSION": "0.6.75"
       }
     }
   }

--- a/packages/codex-plugin/CHANGELOG.md
+++ b/packages/codex-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.75 (2026-09-06)
+
+- Bind Safehouse-backed Codex threads through the shared hook by falling back to `lsof` only when macOS denies `ps`; carries server 0.7.72.
+
 ## 0.6.74 (2026-09-06)
 
 - Carry server 0.7.71 so Safehouse-backed Codex sessions can verify the host through `lsof` when macOS refuses to spawn `ps`.

--- a/packages/codex-plugin/dist/parle-mcp.js
+++ b/packages/codex-plugin/dist/parle-mcp.js
@@ -44624,7 +44624,7 @@ async function safeTool(fn, inferError = true) {
 
 // src/index.ts
 var MCP_CLIENT_NAME = "@parlehq/mcp-server";
-var MCP_CLIENT_VERSION = "0.7.71";
+var MCP_CLIENT_VERSION = "0.7.72";
 var MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 function resolveIntegrationMetadata(env = process.env) {
   const rawName = env.PARLE_INTEGRATION_NAME;

--- a/packages/codex-plugin/hooks/parle-hook.mjs
+++ b/packages/codex-plugin/hooks/parle-hook.mjs
@@ -121,9 +121,25 @@ function isNonResponding(error) {
 const MAX_HOST_ANCESTRY = 8;
 const CODEX_EXECUTABLE_NAME = /^codex(?:[-.][\w.-]*)?$/i;
 
+function processInfoFromLsof(pid, exec = execFileSync) {
+  try {
+    const listing = exec("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-FpRn"], { encoding: "utf8", timeout: 3000, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] });
+    const lines = listing.split("\n");
+    const parentPid = Number(lines.find((entry) => entry.startsWith("R"))?.slice(1));
+    const path = lines.find((entry) => entry.startsWith("n/"))?.slice(1);
+    return { parentPid: Number.isSafeInteger(parentPid) ? parentPid : undefined, path };
+  } catch {
+    return {};
+  }
+}
+
+function psAccessDenied(error) {
+  return ["EACCES", "EPERM"].includes(error?.code) || /\b(?:EACCES|EPERM)\b/.test(error instanceof Error ? error.message : String(error));
+}
+
 // Parent of a live process: /proc where it exists, otherwise the fixed ps
-// binary. Undefined ends the walk.
-function parentPidOf(pid) {
+// binary. Agent Safehouse may deny ps while permitting read-only lsof.
+export function parentPidOf(pid, { exec = execFileSync, platform = process.platform } = {}) {
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
     const parent = Number(stat.slice(stat.lastIndexOf(")") + 2).split(" ")[1]);
@@ -131,40 +147,34 @@ function parentPidOf(pid) {
   } catch {
     // Not Linux, or the process is gone.
   }
-  if (process.platform === "win32") return undefined;
+  if (platform === "win32") return undefined;
   try {
-    const parent = Number(execFileSync("/bin/ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim());
+    const parent = Number(exec("/bin/ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim());
     return Number.isSafeInteger(parent) ? parent : undefined;
-  } catch {
-    return undefined;
+  } catch (error) {
+    return platform === "darwin" && psAccessDenied(error) ? processInfoFromLsof(pid, exec).parentPid : undefined;
   }
 }
 
 // Executable path of a live process without a PATH lookup: /proc where it
-// exists; otherwise ps, which on macOS reports argv[0] as typed, and the lsof
-// text mapping for the absolute path only when that bare name could be Codex.
-function executablePathOf(pid) {
+// exists; otherwise ps, which on macOS reports argv[0] as typed, and lsof for
+// a PATH-launched host or when Agent Safehouse denies ps.
+export function executablePathOf(pid, { exec = execFileSync, platform = process.platform } = {}) {
   try {
     return readlinkSync(`/proc/${pid}/exe`);
   } catch {
     // Not Linux, not our process, or gone.
   }
-  if (process.platform !== "darwin") return undefined;
+  if (platform !== "darwin") return undefined;
   let comm;
   try {
-    comm = execFileSync("/bin/ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim();
-  } catch {
-    return undefined;
+    comm = exec("/bin/ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim();
+  } catch (error) {
+    return psAccessDenied(error) ? processInfoFromLsof(pid, exec).path : undefined;
   }
   if (isAbsolute(comm)) return comm;
   if (!CODEX_EXECUTABLE_NAME.test(basename(comm.replace(/^-/, "")))) return undefined;
-  try {
-    const listing = execFileSync("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { encoding: "utf8", timeout: 3000, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] });
-    const line = listing.split("\n").find((entry) => entry.startsWith("n/"));
-    return line ? line.slice(1) : undefined;
-  } catch {
-    return undefined;
-  }
+  return processInfoFromLsof(pid, exec).path;
 }
 
 // The executable rule the bridge applies to its own parent: owned by this

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/codex-plugin",
-  "version": "0.6.74",
+  "version": "0.6.75",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/codex-plugin/test/hook.test.mjs
+++ b/packages/codex-plugin/test/hook.test.mjs
@@ -16,7 +16,7 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "node:net";
 import { spawn } from "node:child_process";
-import { acceptableHostExecutable } from "../hooks/parle-hook.mjs";
+import { acceptableHostExecutable, executablePathOf, parentPidOf } from "../hooks/parle-hook.mjs";
 
 function withoutAmbientParle(env = process.env) {
   return Object.fromEntries(Object.entries(env).filter(([key]) => !key.startsWith("PARLE_")));
@@ -541,6 +541,29 @@ for (const shell of ["/bin/zsh", "/bin/bash"]) {
     }
   });
 }
+
+test("Codex hook falls back to lsof only when Safehouse denies ps (#204)", () => {
+  const denied = Object.assign(new Error("spawnSync /bin/ps EPERM"), { code: "EPERM" });
+  const calls = [];
+  const exec = (file) => {
+    calls.push(file);
+    if (file === "/bin/ps") throw denied;
+    return "p4242\nR3131\nn/opt/codex/codex\n";
+  };
+
+  assert.equal(parentPidOf(4242, { exec, platform: "darwin" }), 3131);
+  assert.equal(executablePathOf(4242, { exec, platform: "darwin" }), "/opt/codex/codex");
+  assert.deepEqual(calls, ["/bin/ps", "/usr/sbin/lsof", "/bin/ps", "/usr/sbin/lsof"]);
+
+  const unrelatedCalls = [];
+  const unrelated = (file) => {
+    unrelatedCalls.push(file);
+    throw Object.assign(new Error("spawnSync /bin/ps EIO"), { code: "EIO" });
+  };
+  assert.equal(parentPidOf(4242, { exec: unrelated, platform: "darwin" }), undefined);
+  assert.equal(executablePathOf(4242, { exec: unrelated, platform: "darwin" }), undefined);
+  assert.deepEqual(unrelatedCalls, ["/bin/ps", "/bin/ps"], "unrelated ps failures never invoke lsof");
+});
 
 test("Codex hook executable rule accepts user- or root-owned binaries and refuses other owners and loose modes (#174)", () => {
   const uid = 1000;

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.72 (2026-09-06)
+
+- Let the trusted Codex hook use `lsof` for parent and executable discovery only when Agent Safehouse denies `ps`, so the hook can bind the verified thread without broader process permissions.
+
 ## 0.7.71 (2026-09-06)
 
 - On macOS, fall back to `lsof` only when sandbox policy denies `ps`, then retain canonical-path, ownership, mode, inode, version, parent-stability, and pre-exec drift checks before invoking `codex queue`.

--- a/packages/mcp-server/hooks/parle-hook.mjs
+++ b/packages/mcp-server/hooks/parle-hook.mjs
@@ -121,9 +121,25 @@ function isNonResponding(error) {
 const MAX_HOST_ANCESTRY = 8;
 const CODEX_EXECUTABLE_NAME = /^codex(?:[-.][\w.-]*)?$/i;
 
+function processInfoFromLsof(pid, exec = execFileSync) {
+  try {
+    const listing = exec("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-FpRn"], { encoding: "utf8", timeout: 3000, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] });
+    const lines = listing.split("\n");
+    const parentPid = Number(lines.find((entry) => entry.startsWith("R"))?.slice(1));
+    const path = lines.find((entry) => entry.startsWith("n/"))?.slice(1);
+    return { parentPid: Number.isSafeInteger(parentPid) ? parentPid : undefined, path };
+  } catch {
+    return {};
+  }
+}
+
+function psAccessDenied(error) {
+  return ["EACCES", "EPERM"].includes(error?.code) || /\b(?:EACCES|EPERM)\b/.test(error instanceof Error ? error.message : String(error));
+}
+
 // Parent of a live process: /proc where it exists, otherwise the fixed ps
-// binary. Undefined ends the walk.
-function parentPidOf(pid) {
+// binary. Agent Safehouse may deny ps while permitting read-only lsof.
+export function parentPidOf(pid, { exec = execFileSync, platform = process.platform } = {}) {
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
     const parent = Number(stat.slice(stat.lastIndexOf(")") + 2).split(" ")[1]);
@@ -131,40 +147,34 @@ function parentPidOf(pid) {
   } catch {
     // Not Linux, or the process is gone.
   }
-  if (process.platform === "win32") return undefined;
+  if (platform === "win32") return undefined;
   try {
-    const parent = Number(execFileSync("/bin/ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim());
+    const parent = Number(exec("/bin/ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim());
     return Number.isSafeInteger(parent) ? parent : undefined;
-  } catch {
-    return undefined;
+  } catch (error) {
+    return platform === "darwin" && psAccessDenied(error) ? processInfoFromLsof(pid, exec).parentPid : undefined;
   }
 }
 
 // Executable path of a live process without a PATH lookup: /proc where it
-// exists; otherwise ps, which on macOS reports argv[0] as typed, and the lsof
-// text mapping for the absolute path only when that bare name could be Codex.
-function executablePathOf(pid) {
+// exists; otherwise ps, which on macOS reports argv[0] as typed, and lsof for
+// a PATH-launched host or when Agent Safehouse denies ps.
+export function executablePathOf(pid, { exec = execFileSync, platform = process.platform } = {}) {
   try {
     return readlinkSync(`/proc/${pid}/exe`);
   } catch {
     // Not Linux, not our process, or gone.
   }
-  if (process.platform !== "darwin") return undefined;
+  if (platform !== "darwin") return undefined;
   let comm;
   try {
-    comm = execFileSync("/bin/ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim();
-  } catch {
-    return undefined;
+    comm = exec("/bin/ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000, windowsHide: true }).trim();
+  } catch (error) {
+    return psAccessDenied(error) ? processInfoFromLsof(pid, exec).path : undefined;
   }
   if (isAbsolute(comm)) return comm;
   if (!CODEX_EXECUTABLE_NAME.test(basename(comm.replace(/^-/, "")))) return undefined;
-  try {
-    const listing = execFileSync("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "txt", "-Fn"], { encoding: "utf8", timeout: 3000, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] });
-    const line = listing.split("\n").find((entry) => entry.startsWith("n/"));
-    return line ? line.slice(1) : undefined;
-  } catch {
-    return undefined;
-  }
+  return processInfoFromLsof(pid, exec).path;
 }
 
 // The executable rule the bridge applies to its own parent: owned by this

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parlehq/mcp-server",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -15,7 +15,7 @@ export { CODEX_QUEUE_WAKE_TRIGGER, CodexQueueWake, MIN_CODEX_QUEUE_VERSION, reso
 export { CLAUDE_MONITOR_WAKE_FRAME, ClaudeMonitorWake } from "./claude-monitor-wake.js";
 
 export const MCP_CLIENT_NAME = "@parlehq/mcp-server";
-export const MCP_CLIENT_VERSION = "0.7.71";
+export const MCP_CLIENT_VERSION = "0.7.72";
 export const MCP_CLIENT_INSTANCE_ID = processClientInstanceId();
 
 export function resolveIntegrationMetadata(env: Record<string, string | undefined> = process.env): Pick<ClientOptions, "integrationName" | "integrationVersion"> {


### PR DESCRIPTION
## What changed

- fall back to fixed-path `lsof` for hook parent and executable discovery only when macOS denies `/bin/ps` with `EPERM` or `EACCES`
- keep unrelated `ps` failures fail-closed
- add regression coverage and refresh version-matched artifacts

## Verification

- focused Codex hook regression test
- `pnpm typecheck`
- `pnpm check:manifests`
- `pnpm check:mcp-artifacts`
- `pnpm check:release-claims main`
- live Safehouse helper probe resolved both parent and executable without exposing process metadata
- independent security review found no blockers

Closes #204